### PR TITLE
Fix #44

### DIFF
--- a/src/custom-elements.js
+++ b/src/custom-elements.js
@@ -777,7 +777,7 @@ let Deferred;
       const attributeChangedCallback = definition.attributeChangedCallback;
       if (attributeChangedCallback && observedAttributes.indexOf(name) >= 0) {
         const newValue = element.getAttribute(name);
-        if (newValue !== oldValue) {
+        if (newValue !== value) {
           attributeChangedCallback.call(element, name, oldValue, newValue, null);
         }
       }


### PR DESCRIPTION
The change attribute is updating the element to the value of baz. The newValue will be baz and it was being compared to the oldValue or bar, but since it was updated, you should compare the newValue to the value being passed in, which is the value we want.