### PR TITLE
Move bower install into a different npm script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
     - google-chrome-stable
 before_script:
 - export PATH=$PWD/node_modules/.bin:$PATH
+- npm run bower-install
 script:
 - npm run build
 - xvfb-run wct

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/webcomponents/custom-elements/issues"
   },
   "scripts": {
-    "install": "$(npm bin)/bower install",
+    "bower-install": "$(npm bin)/bower install",
     "build": "$(npm bin)/gulp",
     "test": "$(npm bin)/wct"
   },


### PR DESCRIPTION
This moves the `bower install` command into a different npm script. The
"install" script is ran any time someone npm installs this package.
Since this is only used for local development, moving this into a `bower
install` command.

Closes #59