### PR TITLE
Call `connectedCallback` before `disconnectedCallback` if `connectedCallback` is not yet called.

### DIFF
--- a/src/CustomElementInternals.js
+++ b/src/CustomElementInternals.js
@@ -83,7 +83,9 @@ export default class CustomElementInternals {
     for (let i = 0; i < elements.length; i++) {
       const element = elements[i];
       if (element.__CE_state === CEState.custom) {
-        this.connectedCallback(element);
+        if (Utilities.isConnected(element)) {
+          this.connectedCallback(element);
+        }
       } else {
         this.upgradeElement(element);
       }

--- a/src/CustomElementInternals.js
+++ b/src/CustomElementInternals.js
@@ -282,16 +282,24 @@ export default class CustomElementInternals {
     if (definition.connectedCallback) {
       definition.connectedCallback.call(element);
     }
+
+    element.__CE_isConnectedCallbackCalled = true;
   }
 
   /**
    * @param {!Element} element
    */
   disconnectedCallback(element) {
+    if (!element.__CE_isConnectedCallbackCalled) {
+      this.connectedCallback(element);
+    }
+
     const definition = element.__CE_definition;
     if (definition.disconnectedCallback) {
       definition.disconnectedCallback.call(element);
     }
+
+    element.__CE_isConnectedCallbackCalled = undefined;
   }
 
   /**


### PR DESCRIPTION
This fix enables elements to disconnect their child elements during `connectedCallback` by calling `connectedCallback` before `disconnectedCallback` if `connectedCallback` is not yet called.

----
### Rationale

I have been using `@webcomponents/custom-elements@1.0.0-rc2` for [our library](https://github.com/OnsenUI/OnsenUI) since last month, but this code worked differently on the Chrome's CE1 and this polyfill (`@webcomponents/custom-elements@1.0.0-rc2`):

```html
<!DOCTYPE html>
<html>
<head>
  <link rel="shortcut icon" href="">
  <script>
    if (window.customElements) { // even if native CE1 impl exists, use polyfill
        window.customElements.forcePolyfill = true;
    }
  </script>
  <script src="vendor/custom-elements-1.0.0-rc.2/custom-elements.min.js"></script>
  <script>
    customElements.define('x-foo', class extends HTMLElement {
      constructor() {
        super();
        console.log(this.tagName + '#constructor');
      }

      connectedCallback() { console.log(this.tagName + '#connectedCallback');
        // Move the child element to outside of `document`
        document.createElement('div').appendChild(this.firstChild);
      }

      disconnectedCallback() { console.log(this.tagName + '#disconnectedCallback');
      }
    });

    customElements.define('x-bar', class extends HTMLElement {
      constructor() {
        super();
        console.log(this.tagName + '#constructor');
      }

      connectedCallback() { console.log(this.tagName + '#connectedCallback');
      }

      disconnectedCallback() { console.log(this.tagName + '#disconnectedCallback');
      }
    });
  </script>
</head>
<body>
  <script>
    const foo = document.createElement('x-foo');
    {
      const bar = document.createElement('x-bar');
      foo.appendChild(bar);
    }

    document.body.appendChild(foo);
  </script>
</body>
</html>
```

----

Expected (Chrome's CE1):

```
X-FOO#constructor
X-BAR#constructor
X-FOO#connectedCallback
X-BAR#connectedCallback
X-BAR#disconnectedCallback
```

According to 'Timeline' tab of Chrome DevTools, it seems that `x-foo#appendChild` in `x-foo#connectedCallback` called `x-bar#connectedCallback` before `x-bar#disconnectedCallback`:

![2017-04-12 15 35 58](https://cloud.githubusercontent.com/assets/19771915/24944362/ca4b2748-1f95-11e7-876f-fe8b42fce711.png)

----

Result (this polyfill (`@webcomponents/custom-elements@1.0.0-rc2`)):

```
X-FOO#constructor
X-BAR#constructor
X-FOO#connectedCallback
X-BAR#disconnectedCallback
X-BAR#connectedCallback
```

![2017-04-12 15 54 18](https://cloud.githubusercontent.com/assets/19771915/24944962/55af532a-1f98-11e7-9568-0dd8d0ba7a46.png)

----
### Content of this PR

I have changed the following methods:

- CustomElementInternals#connectTree
  - Suppress `connectedCallback` on elements which are already disconnected in another `connectedCallback`.
- CustomElementInternals#connectedCallback
  - Set `element.__CE_isConnectedCallbackCalled` to `true`.
- CustomElementInternals#disconnectedCallback
  - Call `CustomElementInternals#connectedCallback` as needed.
  - Set `element.__CE_isConnectedCallbackCalled` to `undefined`.

----
I wanted to avoid using `element.__CE_isConnectedCallbackCalled`, but I could not find any other way.
Also, I think there might be more methods I should fix.

Could you review this PR please?