### PR TITLE
Add sudo: required to Travis config for running Chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js: 6
 dist: trusty
+sudo: required
 addons:
   firefox: latest
   apt:


### PR DESCRIPTION
This is incorrect information:

![](https://i.imgur.com/Qlc6r0p.png)

The current master is failing. And you guys should have nightly builds enabled for important repositories like this one. Read more about enabling scheduled builds in Travis: https://docs.travis-ci.com/user/cron-jobs/

Reason: https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524

Failing build example: https://travis-ci.org/webcomponents/custom-elements/builds/326854759

![](https://i.imgur.com/b44fz0x.png)

---

PS. about the importance of nightly builds: 

[The Joel Test: 12 Steps to Better Code ↗](http://www.joelonsoftware.com/articles/fog0000000043.html)

> **3. Do you make daily builds?**
> 
> When you're using source control, sometimes one programmer
> accidentally checks in something that breaks the build. *For example,
> they've added a new source file, and everything compiles fine on their
> machine, but they forgot to add the source file to the code
> repository. So they lock their machine and go home, oblivious and
> happy. But nobody else can work, so they have to go home too, unhappy.*
> 
> Breaking the build is so bad (and so common) that it helps to make
> daily builds, to insure that no breakage goes unnoticed. *On large
> teams, one good way to insure that breakages are fixed right away is
> to do the daily build every afternoon at, say, lunchtime. Everyone
> does as many checkins as possible before lunch. When they come back,
> the build is done. If it worked, great! Everybody checks out the
> latest version of the source and goes on working. If the build failed,
> you fix it, but everybody can keep on working with the pre-build,
> unbroken version of the source.*
> 
> On the Excel team we had a rule that whoever broke the build, as their
> "punishment", was responsible for babysitting the builds until someone
> else broke it. This was a good incentive not to break the build, and a
> good way to rotate everyone through the build process so that everyone
> learned how it worked.
  
  