### PR TITLE
pin es6-promise to 4.1.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "web-component-tester": "^6.0.0",
     "webcomponents-platform": "webcomponents/webcomponents-platform#^1.0.0",
-    "es6-promise": "stefanpenner/es6-promise#^4.0.0",
+    "es6-promise": "stefanpenner/es6-promise#4.1.1",
     "html-imports": "webcomponents/html-imports#^1.0.0",
     "template": "webcomponents/template#^1.2.0",
     "shadydom": "webcomponents/shadydom#^1.0.6"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@webcomponents/template": "^1.0.0",
     "@webcomponents/webcomponents-platform": "^1.0.0",
     "bower": "^1.8.0",
-    "es6-promise": "^4.1.0",
+    "es6-promise": "4.1.1",
     "google-closure-compiler": "^20170409.0.0",
     "gulp": "^3.8.8",
     "gulp-sourcemaps": "^1.6.0",


### PR DESCRIPTION
4.2.0 removes the dist directory containing the pre-built polyfill:
https://github.com/stefanpenner/es6-promise/issues/231
https://github.com/stefanpenner/es6-promise/pull/312