### PR TITLE
Fix #137: prefer `document.createElement` to `Document.prototype.createElement` for LastPass

### DIFF
--- a/src/Patch/Document.js
+++ b/src/Patch/Document.js
@@ -8,26 +8,36 @@ import PatchParentNode from './Interface/ParentNode.js';
  * @param {!CustomElementInternals} internals
  */
 export default function(internals) {
-  Utilities.setPropertyUnchecked(Document.prototype, 'createElement',
-    /**
-     * @this {Document}
-     * @param {string} localName
-     * @return {!Element}
-     */
-    function(localName) {
-      // Only create custom elements if this document is associated with the registry.
-      if (this.__CE_hasRegistry) {
-        const definition = internals.localNameToDefinition(localName);
-        if (definition) {
-          return new (definition.constructor)();
+  function patch_createElement(baseFunction) {
+    Utilities.setPropertyUnchecked(Document.prototype, 'createElement',
+      /**
+       * @this {Document}
+       * @param {string} localName
+       * @return {!Element}
+       */
+      function(localName) {
+        // Only create custom elements if this document is associated with the registry.
+        if (this.__CE_hasRegistry) {
+          const definition = internals.localNameToDefinition(localName);
+          if (definition) {
+            return new (definition.constructor)();
+          }
         }
-      }
 
-      const result = /** @type {!Element} */
-        (Native.Document_createElement.call(this, localName));
-      internals.patch(result);
-      return result;
-    });
+        const result = /** @type {!Element} */
+          (baseFunction.call(this, localName));
+        internals.patch(result);
+        return result;
+      });
+  };
+
+  const singletonDesc = Native.window_document_createElement;
+  if (singletonDesc && typeof singletonDesc.value === "function") {
+    patch_createElement(singletonDesc.value);
+    delete document.createElement;
+  } else {
+    patch_createElement(Native.Document_createElement);
+  }
 
   Utilities.setPropertyUnchecked(Document.prototype, 'importNode',
     /**

--- a/src/Patch/Native.js
+++ b/src/Patch/Native.js
@@ -1,4 +1,5 @@
 export default {
+  window_document_createElement: Object.getOwnPropertyDescriptor(window.document, 'createElement'),
   Document_createElement: window.Document.prototype.createElement,
   Document_createElementNS: window.Document.prototype.createElementNS,
   Document_importNode: window.Document.prototype.importNode,


### PR DESCRIPTION
I still need to actually try this out, please don't merge yet.

cc @usergenic; it won't let me add you as a reviewer for some reason.