### PR TITLE
Allow ES6 classes through native-shim.js

### DIFF
--- a/src/native-shim.js
+++ b/src/native-shim.js
@@ -55,31 +55,18 @@
 
   var NativeHTMLElement = window.HTMLElement, newHTMLElement;
 
-  try {
-    // Try first with new.target support. Use "eval" in case it does not exists.
-    newHTMLElement = eval(`(function(_super) {
-      return function HTMLElement() {
-        return _super(this, new.target || this.constructor);
-      }
-    })`)(_super);
-  } catch (e) { // Failed on new.target ?
-    newHTMLElement = function HTMLElement() {
-      return _super(this, this.constructor);
-    };
-  }
+  newHTMLElement = function HTMLElement() {
+    // Tries to make a super call to the native HTMLElement with the first available solution.
+    if (typeof Reflect === 'object' && typeof Reflect.construct === 'function') {
+      return Reflect.construct(NativeHTMLElement, [], this.constructor);
+    } else {
+      return NativeHTMLElement.call(this);
+    }
+  };
 
   // Object.setPrototypeOf is surprisingly supported in IE 11
   Object.setPrototypeOf(newHTMLElement.prototype, NativeHTMLElement.prototype);
   Object.setPrototypeOf(newHTMLElement, NativeHTMLElement);
 
   window.HTMLElement = newHTMLElement;
-
-  // Tries to make a super call to the native HTMLElement with the first available solution.
-  function _super(_this, _target) {
-    if (typeof Reflect === 'object' && typeof Reflect.construct === 'function') {
-      return Reflect.construct(NativeHTMLElement, [], _target);
-    } else {
-      return NativeHTMLElement.call(_this);
-    }
-  }
 })();

--- a/src/native-shim.js
+++ b/src/native-shim.js
@@ -16,27 +16,16 @@
  * HTMLElement constructor uses the value of `new.target` to look up the custom
  * element definition for the currently called constructor. `new.target` is only
  * set when `new` is called and is only propagated via super() calls. super()
- * is not emulatable in ES5. The pattern of `SuperClass.call(this)`` only works
+ * is not emulatable in ES5. The pattern of `SuperClass.call(this)` only works
  * when extending other ES5-style classes, and does not propagate `new.target`.
  *
- * This shim allows the native HTMLElement constructor to work by generating and
- * registering a stand-in class instead of the users custom element class. This
- * stand-in class's constructor has an actual call to super().
- * `customElements.define()` and `customElements.get()` are both overridden to
- * hide this stand-in class from users.
- *
- * In order to create instance of the user-defined class, rather than the stand
- * in, the stand-in's constructor swizzles its instances prototype and invokes
- * the user-defined constructor. When the user-defined constructor is called
- * directly it creates an instance of the stand-in class to get a real extension
- * of HTMLElement and returns that.
- *
- * There are two important constructors: A patched HTMLElement constructor, and
- * the StandInElement constructor. They both will be called to create an element
- * but which is called first depends on whether the browser creates the element
- * or the user-defined constructor is called directly. The variables
- * `browserConstruction` and `userConstruction` control the flow between the
- * two constructors.
+ * This shim allows the native HTMLElement constructor to work by overriding the
+ * HTMLElement class with a subclass that will try its best to provide to catch
+ * up the lack of super call for you. Old inheritance with `SuperClass.call(this)`
+ * pattern is still required.
+ * 
+ * Since both subclasses will be supported by the custom element registry, this
+ * shim will let you develop with the target transpilation of your choice.
  *
  * This shim should be better than forcing the polyfill because:
  *   1. It's smaller
@@ -44,9 +33,9 @@
  *   3. All reaction triggering DOM operations are automatically supported
  *
  * There are some restrictions and requirements on ES5 constructors:
- *   1. All constructors in a inheritance hierarchy must be ES5-style, so that
- *      they can be called with Function.call(). This effectively means that the
- *      whole application must be compiled to ES5.
+ *   1. All constructors in a inheritance hierarchy must be ES5-style with
+ *      `SuperClass.call(this)` pattern or ES6-style with a real or emulated
+ *      (with `Reflect.construct`) super() call.
  *   2. Constructors must return the value of the emulated super() call. Like
  *      `return SuperClass.call(this)`
  *   3. The `this` reference should not be used before the emulated super() call
@@ -55,110 +44,42 @@
  *      super() call. This is the same restriction as with native custom
  *      elements.
  *
- *  Compiling valid class-based custom elements to ES5 will satisfy these
+ *  Compiling valid class-based custom elements to ES5 or ES6 will satisfy these
  *  requirements with the latest version of popular transpilers.
  */
-(() => {
+(function() {
   'use strict';
 
   // Do nothing if `customElements` does not exist.
   if (!window.customElements) return;
 
-  const NativeHTMLElement = window.HTMLElement;
-  const nativeDefine = window.customElements.define;
-  const nativeGet = window.customElements.get;
+  var NativeHTMLElement = window.HTMLElement, newHTMLElement;
 
-  /**
-   * Map of user-provided constructors to tag names.
-   *
-   * @type {Map<Function, string>}
-   */
-  const tagnameByConstructor = new Map();
-
-  /**
-   * Map of tag names to user-provided constructors.
-   *
-   * @type {Map<string, Function>}
-   */
-  const constructorByTagname = new Map();
-
-
-  /**
-   * Whether the constructors are being called by a browser process, ie parsing
-   * or createElement.
-   */
-  let browserConstruction = false;
-
-  /**
-   * Whether the constructors are being called by a user-space process, ie
-   * calling an element constructor.
-   */
-  let userConstruction = false;
-
-  window.HTMLElement = function() {
-    if (!browserConstruction) {
-      const tagname = tagnameByConstructor.get(this.constructor);
-      const fakeClass = nativeGet.call(window.customElements, tagname);
-
-      // Make sure that the fake constructor doesn't call back to this constructor
-      userConstruction = true;
-      const instance = new (fakeClass)();
-      return instance;
-    }
-    // Else do nothing. This will be reached by ES5-style classes doing
-    // HTMLElement.call() during initialization
-    browserConstruction = false;
-  };
-  // By setting the patched HTMLElement's prototype property to the native
-  // HTMLElement's prototype we make sure that:
-  //     document.createElement('a') instanceof HTMLElement
-  // works because instanceof uses HTMLElement.prototype, which is on the
-  // ptototype chain of built-in elements.
-  window.HTMLElement.prototype = NativeHTMLElement.prototype;
-
-  const define = (tagname, elementClass) => {
-    const elementProto = elementClass.prototype;
-    const StandInElement = class extends NativeHTMLElement {
-      constructor() {
-        // Call the native HTMLElement constructor, this gives us the
-        // under-construction instance as `this`:
-        super();
-
-        // The prototype will be wrong up because the browser used our fake
-        // class, so fix it:
-        Object.setPrototypeOf(this, elementProto);
-
-        if (!userConstruction) {
-          // Make sure that user-defined constructor bottom's out to a do-nothing
-          // HTMLElement() call
-          browserConstruction = true;
-          // Call the user-defined constructor on our instance:
-          elementClass.call(this);
-        }
-        userConstruction = false;
+  try {
+    // Try first with new.target support. Use "eval" in case it does not exists.
+    newHTMLElement = eval(`(function(_super) {
+      return function HTMLElement() {
+        return _super(this, new.target || this.constructor);
       }
+    })`)(_super);
+  } catch (e) { // Failed on new.target ?
+    newHTMLElement = function HTMLElement() {
+      return _super(this, this.constructor);
     };
-    const standInProto = StandInElement.prototype;
-    StandInElement.observedAttributes = elementClass.observedAttributes;
-    standInProto.connectedCallback = elementProto.connectedCallback;
-    standInProto.disconnectedCallback = elementProto.disconnectedCallback;
-    standInProto.attributeChangedCallback = elementProto.attributeChangedCallback;
-    standInProto.adoptedCallback = elementProto.adoptedCallback;
+  }
 
-    tagnameByConstructor.set(elementClass, tagname);
-    constructorByTagname.set(tagname, elementClass);
-    nativeDefine.call(window.customElements, tagname, StandInElement);
-  };
+  // Object.setPrototypeOf is surprisingly supported in IE 11
+  Object.setPrototypeOf(newHTMLElement.prototype, NativeHTMLElement.prototype);
+  Object.setPrototypeOf(newHTMLElement, NativeHTMLElement);
 
-  const get = (tagname) => constructorByTagname.get(tagname);
+  window.HTMLElement = newHTMLElement;
 
-  // Workaround for Safari bug where patching customElements can be lost, likely
-  // due to native wrapper garbage collection issue
-  Object.defineProperty(window, 'customElements',
-    {value: window.customElements, configurable: true, writable: true});
-  Object.defineProperty(window.customElements, 'define',
-    {value: define, configurable: true, writable: true});
-  Object.defineProperty(window.customElements, 'get',
-    {value: get, configurable: true, writable: true});
-
+  // Tries to make a super call to the native HTMLElement with the first available solution.
+  function _super(_this, _target) {
+    if (typeof Reflect === 'object' && typeof Reflect.construct === 'function') {
+      return Reflect.construct(NativeHTMLElement, [], _target);
+    } else {
+      return NativeHTMLElement.call(_this);
+    }
+  }
 })();

--- a/tests/html/shim.html
+++ b/tests/html/shim.html
@@ -16,102 +16,299 @@
 
 <script>
 
-  suite('Native Shim', () => {
+suite('Native Shim', () => {
 
-    // Do nothing if the browser does not natively support custom elements.
-    if (!window.customElements) {
-      test.skip('The native shim does not apply to this browser.', () => {});
-      return;
+  // Do nothing if the browser does not natively support custom elements.
+  if (!window.customElements) {
+    test.skip('The native shim does not apply to this browser.', () => {});
+    return;
+  }
+
+  test('works with createElement()', () => {
+    function ES5Element1() {
+      return HTMLElement.apply(this);
     }
+    ES5Element1.prototype = Object.create(HTMLElement.prototype);
+    ES5Element1.prototype.constructor = ES5Element1;
 
-    test('works with createElement()', () => {
-      function ES5Element1() {
-        return HTMLElement.apply(this);
-      }
-      ES5Element1.prototype = Object.create(HTMLElement.prototype);
-      ES5Element1.prototype.constructor = ES5Element1;
+    customElements.define('es5-element-1', ES5Element1);
 
-      customElements.define('es5-element-1', ES5Element1);
+    const el = document.createElement('es5-element-1');
+    assert.instanceOf(el, ES5Element1);
+    assert.instanceOf(el, HTMLElement);
+    assert.equal(el.tagName, 'ES5-ELEMENT-1');
+  });
 
-      const el = document.createElement('es5-element-1');
-      assert.instanceOf(el, ES5Element1);
-      assert.instanceOf(el, HTMLElement);
-      assert.equal(el.tagName, 'ES5-ELEMENT-1');
-    });
+  test('works with user-called constructors', () => {
+    function ES5Element2() {
+      return HTMLElement.apply(this);
+    }
+    ES5Element2.prototype = Object.create(HTMLElement.prototype);
+    ES5Element2.prototype.constructor = ES5Element2;
 
-    test('works with user-called constructors', () => {
-      function ES5Element2() {
-        return HTMLElement.apply(this);
-      }
-      ES5Element2.prototype = Object.create(HTMLElement.prototype);
-      ES5Element2.prototype.constructor = ES5Element2;
+    customElements.define('es5-element-2', ES5Element2);
 
-      customElements.define('es5-element-2', ES5Element2);
+    const el = new ES5Element2();
+    assert.instanceOf(el, ES5Element2);
+    assert.instanceOf(el, HTMLElement);
+    assert.equal(el.tagName, 'ES5-ELEMENT-2');
+  });
 
-      const el = new ES5Element2();
-      assert.instanceOf(el, ES5Element2);
-      assert.instanceOf(el, HTMLElement);
-      assert.equal(el.tagName, 'ES5-ELEMENT-2');
-    });
+  test('works with parser created elements', () => {
+    function ES5Element3() {
+      return HTMLElement.apply(this);
+    }
+    ES5Element3.prototype = Object.create(HTMLElement.prototype);
+    ES5Element3.prototype.constructor = ES5Element3;
 
-    test('works with parser created elements', () => {
-      function ES5Element3() {
-        return HTMLElement.apply(this);
-      }
-      ES5Element3.prototype = Object.create(HTMLElement.prototype);
-      ES5Element3.prototype.constructor = ES5Element3;
+    customElements.define('es5-element-3', ES5Element3);
 
-      customElements.define('es5-element-3', ES5Element3);
+    const container = document.createElement('div');
+    container.innerHTML = '<es5-element-3></es5-element-3>';
+    const el = container.querySelector('es5-element-3');
+    assert.instanceOf(el, ES5Element3);
+    assert.instanceOf(el, HTMLElement);
+    assert.equal(el.tagName, 'ES5-ELEMENT-3');
+  });
 
-      const container = document.createElement('div');
-      container.innerHTML = '<es5-element-3></es5-element-3>';
-      const el = container.querySelector('es5-element-3');
-      assert.instanceOf(el, ES5Element3);
-      assert.instanceOf(el, HTMLElement);
-      assert.equal(el.tagName, 'ES5-ELEMENT-3');
-    });
+  test('reactions', () => {
+    function ES5Element4() {
+      return HTMLElement.apply(this);
+    }
+    ES5Element4.prototype = Object.create(HTMLElement.prototype);
+    ES5Element4.prototype.constructor = ES5Element4;
+    ES5Element4.observedAttributes = ['test'];
+    ES5Element4.prototype.connectedCallback = function() {
+      this.connectedCalled = true;
+    };
+    ES5Element4.prototype.disconnectedCallback = function() {
+      this.disconnectedCalled = true;
+    };
+    ES5Element4.prototype.attributeChangedCallback = function(name, oldValue, newValue) {
+      this.attributeChangedCalled = `${name}, ${oldValue}, ${newValue}`;
+    };
+    ES5Element4.prototype.adoptedCallback = function() {
+      this.adoptedCalled = true;
+    };
 
-    test('reactions', () => {
-      function ES5Element4() {
-        return HTMLElement.apply(this);
-      }
-      ES5Element4.prototype = Object.create(HTMLElement.prototype);
-      ES5Element4.prototype.constructor = ES5Element4;
-      ES5Element4.observedAttributes = ['test'];
-      ES5Element4.prototype.connectedCallback = function() {
-        this.connectedCalled = true;
-      };
-      ES5Element4.prototype.disconnectedCallback = function() {
-        this.disconnectedCalled = true;
-      };
-      ES5Element4.prototype.attributeChangedCallback = function(name, oldValue, newValue) {
-        this.attributeChangedCalled = `${name}, ${oldValue}, ${newValue}`;
-      };
-      ES5Element4.prototype.adoptedCallback = function() {
-        this.adoptedCalled = true;
-      };
+    customElements.define('es5-element-4', ES5Element4);
 
-      customElements.define('es5-element-4', ES5Element4);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
 
-      const container = document.createElement('div');
-      document.body.appendChild(container);
+    const el = new ES5Element4();
 
-      const el = new ES5Element4();
+    container.appendChild(el);
+    assert(el.connectedCalled);
 
-      container.appendChild(el);
-      assert(el.connectedCalled);
+    container.removeChild(el);
+    assert(el.disconnectedCalled);
 
-      container.removeChild(el);
-      assert(el.disconnectedCalled);
+    el.setAttribute('test', 'good');
+    assert.equal(el.attributeChangedCalled, 'test, null, good');
 
-      el.setAttribute('test', 'good');
-      assert.equal(el.attributeChangedCalled, 'test, null, good');
-
-      const doc = document.implementation.createHTMLDocument();
-      doc.adoptNode(el);
-      assert(el.adoptedCalled);
-
-    });
+    const doc = document.implementation.createHTMLDocument();
+    doc.adoptNode(el);
+    assert(el.adoptedCalled);
 
   });
+
+});
+
+suite('Native Shim with ES5 + Reflect API super call (can be expected from transpilers)', () => {
+
+  // Do nothing if the browser does not natively support custom elements.
+  if (!window.customElements) {
+    test.skip('The native shim does not apply to this browser.', () => {});
+    return;
+  }
+  // Do nothing if the browser does not support Reflect API.
+  if (typeof Reflect !== 'object' || typeof Reflect.construct !== 'function') {
+    test.skip('This test suite does not apply to this browser (Reflect API missing).', () => {});
+    return;
+  }
+
+  test('works with createElement()', () => {
+    function ES5ReflectReflect1() {
+      return Reflect.construct(HTMLElement, [], this.constructor);
+    }
+    ES5ReflectReflect1.prototype = Object.create(HTMLElement.prototype);
+    ES5ReflectReflect1.prototype.constructor = ES5ReflectReflect1;
+
+    customElements.define('es5-reflect-element-1', ES5ReflectReflect1);
+
+    const el = document.createElement('es5-reflect-element-1');
+    assert.instanceOf(el, ES5ReflectReflect1);
+    assert.instanceOf(el, HTMLElement);
+    assert.equal(el.tagName, 'ES5-REFLECT-ELEMENT-1');
+  });
+
+  test('works with user-called constructors', () => {
+    function ES5ReflectReflect2() {
+      return Reflect.construct(HTMLElement, [], this.constructor);
+    }
+    ES5ReflectReflect2.prototype = Object.create(HTMLElement.prototype);
+    ES5ReflectReflect2.prototype.constructor = ES5ReflectReflect2;
+
+    customElements.define('es5-reflect-element-2', ES5ReflectReflect2);
+
+    const el = new ES5ReflectReflect2();
+    assert.instanceOf(el, ES5ReflectReflect2);
+    assert.instanceOf(el, HTMLElement);
+    assert.equal(el.tagName, 'ES5-REFLECT-ELEMENT-2');
+  });
+
+  test('works with parser created elements', () => {
+    function ES5ReflectReflect3() {
+      return Reflect.construct(HTMLElement, [], this.constructor);
+    }
+    ES5ReflectReflect3.prototype = Object.create(HTMLElement.prototype);
+    ES5ReflectReflect3.prototype.constructor = ES5ReflectReflect3;
+
+    customElements.define('es5-reflect-element-3', ES5ReflectReflect3);
+
+    const container = document.createElement('div');
+    container.innerHTML = '<es5-reflect-element-3></es5-reflect-element-3>';
+    const el = container.querySelector('es5-reflect-element-3');
+    assert.instanceOf(el, ES5ReflectReflect3);
+    assert.instanceOf(el, HTMLElement);
+    assert.equal(el.tagName, 'ES5-REFLECT-ELEMENT-3');
+  });
+
+  test('reactions', () => {
+    function ES5ReflectElement4() {
+      return Reflect.construct(HTMLElement, [], this.constructor);
+    }
+    ES5ReflectElement4.prototype = Object.create(HTMLElement.prototype);
+    ES5ReflectElement4.prototype.constructor = ES5ReflectElement4;
+    ES5ReflectElement4.observedAttributes = ['test'];
+    ES5ReflectElement4.prototype.connectedCallback = function() {
+      this.connectedCalled = true;
+    };
+    ES5ReflectElement4.prototype.disconnectedCallback = function() {
+      this.disconnectedCalled = true;
+    };
+    ES5ReflectElement4.prototype.attributeChangedCallback = function(name, oldValue, newValue) {
+      this.attributeChangedCalled = `${name}, ${oldValue}, ${newValue}`;
+    };
+    ES5ReflectElement4.prototype.adoptedCallback = function() {
+      this.adoptedCalled = true;
+    };
+
+    customElements.define('es5-reflect-element-4', ES5ReflectElement4);
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const el = new ES5ReflectElement4();
+
+    container.appendChild(el);
+    assert(el.connectedCalled);
+
+    container.removeChild(el);
+    assert(el.disconnectedCalled);
+
+    el.setAttribute('test', 'good');
+    assert.equal(el.attributeChangedCalled, 'test, null, good');
+
+    const doc = document.implementation.createHTMLDocument();
+    doc.adoptNode(el);
+    assert(el.adoptedCalled);
+
+  });
+});
+
+suite('Native Shim with ES6 classes', () => {
+
+  // Do nothing if the browser does not natively support custom elements.
+  if (!window.customElements) {
+    test.skip('The native shim does not apply to this browser.', () => {});
+    return;
+  }
+
+  function createHTMLElementSubclassNamed(name) {
+    return eval('(function() { class ' + name + ' extends HTMLElement { constructor() { super(); }}; return ' + name + '; })')();
+  }
+
+  try {
+    createHTMLElementSubclassNamed('ES6Element0');
+  } catch (e) {
+    test.skip('This test suite does not apply to this browser (ES6 classes not supported).', () => {});
+    return;
+  }
+
+  test('works with createElement()', () => {
+    var ES6Element1 = createHTMLElementSubclassNamed('ES6Element1');
+
+    customElements.define('es6-element-1', ES6Element1);
+
+    const el = document.createElement('es6-element-1');
+    assert.instanceOf(el, ES6Element1);
+    assert.instanceOf(el, HTMLElement);
+    assert.equal(el.tagName, 'ES6-ELEMENT-1');
+  });
+
+  test('works with user-called constructors', () => {
+    var ES6Element2 = createHTMLElementSubclassNamed('ES6Element2');
+
+    customElements.define('es6-element-2', ES6Element2);
+
+    const el = new ES6Element2();
+    assert.instanceOf(el, ES6Element2);
+    assert.instanceOf(el, HTMLElement);
+    assert.equal(el.tagName, 'ES6-ELEMENT-2');
+  });
+
+  test('works with parser created elements', () => {
+    ES6Element3 = createHTMLElementSubclassNamed('ES6Element3');
+
+    customElements.define('es6-element-3', ES6Element3);
+
+    const container = document.createElement('div');
+    container.innerHTML = '<es6-element-3></es6-element-3>';
+    const el = container.querySelector('es6-element-3');
+    assert.instanceOf(el, ES6Element3);
+    assert.instanceOf(el, HTMLElement);
+    assert.equal(el.tagName, 'ES6-ELEMENT-3');
+  });
+
+  test('reactions', () => {
+    ES6Element4 = createHTMLElementSubclassNamed('ES6Element4');
+    ES6Element4.observedAttributes = ['test'];
+    ES6Element4.prototype.connectedCallback = function() {
+      this.connectedCalled = true;
+    };
+    ES6Element4.prototype.disconnectedCallback = function() {
+      this.disconnectedCalled = true;
+    };
+    ES6Element4.prototype.attributeChangedCallback = function(name, oldValue, newValue) {
+      this.attributeChangedCalled = `${name}, ${oldValue}, ${newValue}`;
+    };
+    ES6Element4.prototype.adoptedCallback = function() {
+      this.adoptedCalled = true;
+    };
+
+    customElements.define('es6-element-4', ES6Element4);
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const el = new ES6Element4();
+
+    container.appendChild(el);
+    assert(el.connectedCalled);
+
+    container.removeChild(el);
+    assert(el.disconnectedCalled);
+
+    el.setAttribute('test', 'good');
+    assert.equal(el.attributeChangedCalled, 'test, null, good');
+
+    const doc = document.implementation.createHTMLDocument();
+    doc.adoptNode(el);
+    assert(el.adoptedCalled);
+
+  });
+
+});
 </script>


### PR DESCRIPTION
Fixes #142.

I only have Chrome and IE 11 available to run the tests, I completed them to make sure any issue is raised ASAP.

Reworked the native-shim.js to have a valid syntax for IE11 (one can only copy this shim and have no penalty on IE 11)