### PR TITLE
Replace broken 'gulp debug' with 'npm run debug'

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,8 +13,6 @@
 const compilerPackage = require('google-closure-compiler');
 const gulp = require('gulp');
 const sourcemaps = require('gulp-sourcemaps');
-const rollup = require('rollup-stream');
-const source = require('vinyl-source-stream');
 
 const closureCompiler = compilerPackage.gulp();
 
@@ -36,16 +34,5 @@ gulp.task('default', () => {
       rewrite_polyfills: false,
     }))
     .pipe(sourcemaps.write('/'))
-    .pipe(gulp.dest('./'));
-});
-
-gulp.task('debug', () => {
-  return rollup({
-      entry: './src/custom-elements.js',
-      format: 'iife',
-      sourceMap: false,
-      indent: true,
-    })
-    .pipe(source('custom-elements.min.js'))
     .pipe(gulp.dest('./'));
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9109,18 +9109,13 @@
       }
     },
     "rollup": {
-      "version": "0.49.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.49.3.tgz",
-      "integrity": "sha512-n/vHRX4GhMIyGZEQRANcSFVtvz99bSRbNMuoC33ar9f4CViqffyF9WklLb2mxIQ6I/uFf7wDEpc66bXBFE7FvA==",
-      "dev": true
-    },
-    "rollup-stream": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/rollup-stream/-/rollup-stream-1.24.1.tgz",
-      "integrity": "sha512-iQ159xbWSOPc7ey8tjEYf7pCaQwBz3ov37KNCeDewqh6Qj1gntAgZSmmEJIPs2niXMDNqVZ3rnTFXBXhZ+sYSg==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.62.0.tgz",
+      "integrity": "sha512-mZS0aIGfYzuJySJD78znu9/hCJsNfBzg4lDuZGMj0hFVcYHt2evNRHv8aqiu9/w6z6Qn8AQoVl4iyEjDmisGeA==",
       "dev": true,
       "requires": {
-        "rollup": "^0.49.2"
+        "@types/estree": "0.0.39",
+        "@types/node": "*"
       }
     },
     "safe-buffer": {
@@ -10934,40 +10929,6 @@
           "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
           "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
           "dev": true
-        }
-      }
-    },
-    "vinyl-source-stream": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
-      "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
-      "dev": true,
-      "requires": {
-        "through2": "^2.0.3",
-        "vinyl": "^0.4.3"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-          "dev": true
-        },
-        "clone-stats": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-          "dev": true
-        },
-        "vinyl": {
-          "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-          "dev": true,
-          "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "scripts": {
     "build": "gulp",
+    "debug": "rollup -c",
     "test": "wct",
     "prepack": "npm run build"
   },
@@ -43,8 +44,7 @@
     "google-closure-compiler": "^20170409.0.0",
     "gulp": "^4.0.0",
     "gulp-sourcemaps": "^1.6.0",
-    "rollup-stream": "^1.14.0",
-    "vinyl-source-stream": "^1.1.0",
+    "rollup": "^0.62.0",
     "wct-browser-legacy": "^1.0.1",
     "web-component-tester": "^6.7.1"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,6 @@
+const config = {
+  input: 'src/custom-elements.js',
+  output: { exports: 'named', file: 'custom-elements.min.js', format: 'iife', name: 'CustomElements', sourcemap: true }
+};
+
+export default config;


### PR DESCRIPTION
The gulp debug build command was broken and did not produce any output. I replaced it with a functionally identical npm run debug command that invokes Rollup directly to produce the same output.