### PR TITLE
Fix `HTMLElement.name`.

### DIFF
--- a/src/native-shim.js
+++ b/src/native-shim.js
@@ -27,7 +27,7 @@
     return;
   }
   const BuiltInHTMLElement = HTMLElement;
-  window.HTMLElement = function() {
+  window.HTMLElement = function HTMLElement() {
     return Reflect.construct(BuiltInHTMLElement, [], this.constructor);
   };
   HTMLElement.prototype = BuiltInHTMLElement.prototype;

--- a/tests/html/shim.html
+++ b/tests/html/shim.html
@@ -17,7 +17,9 @@
 
 suite('Native Shim', () => {
 
-  suiteSetup(function() {
+  // Calling `this.skip` in `suiteSetup` does not prevent descendant suites
+  // from running. Instead, this skips each test individually.
+  setup(function() {
     // Do nothing if the browser does not natively support custom elements.
     if (!window.customElements) {
       this.skip();
@@ -25,285 +27,282 @@ suite('Native Shim', () => {
     }
   });
 
-  test('works with createElement()', () => {
-    function ES5Element1() {
-      return HTMLElement.apply(this);
-    }
-    ES5Element1.prototype = Object.create(HTMLElement.prototype);
-    ES5Element1.prototype.constructor = ES5Element1;
+  test('`HTMLElement` has the name "HTMLElement"', () => {
+    assert.equal(window.HTMLElement.name, 'HTMLElement');
 
-    customElements.define('es5-element-1', ES5Element1);
-
-    const el = document.createElement('es5-element-1');
-    assert.instanceOf(el, ES5Element1);
-    assert.instanceOf(el, HTMLElement);
-    assert.equal(el.tagName, 'ES5-ELEMENT-1');
+    const element = document.createElement('not-customized');
+    assert.equal(element.constructor.name, 'HTMLElement');
   });
 
-  test('works with user-called constructors', () => {
-    function ES5Element2() {
-      return HTMLElement.apply(this);
-    }
-    ES5Element2.prototype = Object.create(HTMLElement.prototype);
-    ES5Element2.prototype.constructor = ES5Element2;
+  suite('Extending HTMLElement with ES5 without Reflect', () => {
 
-    customElements.define('es5-element-2', ES5Element2);
+    test('works with createElement()', () => {
+      function ES5Element1() {
+        return HTMLElement.apply(this);
+      }
+      ES5Element1.prototype = Object.create(HTMLElement.prototype);
+      ES5Element1.prototype.constructor = ES5Element1;
 
-    const el = new ES5Element2();
-    assert.instanceOf(el, ES5Element2);
-    assert.instanceOf(el, HTMLElement);
-    assert.equal(el.tagName, 'ES5-ELEMENT-2');
-  });
+      customElements.define('es5-element-1', ES5Element1);
 
-  test('works with parser created elements', () => {
-    function ES5Element3() {
-      return HTMLElement.apply(this);
-    }
-    ES5Element3.prototype = Object.create(HTMLElement.prototype);
-    ES5Element3.prototype.constructor = ES5Element3;
+      const el = document.createElement('es5-element-1');
+      assert.instanceOf(el, ES5Element1);
+      assert.instanceOf(el, HTMLElement);
+      assert.equal(el.tagName, 'ES5-ELEMENT-1');
+    });
 
-    customElements.define('es5-element-3', ES5Element3);
+    test('works with user-called constructors', () => {
+      function ES5Element2() {
+        return HTMLElement.apply(this);
+      }
+      ES5Element2.prototype = Object.create(HTMLElement.prototype);
+      ES5Element2.prototype.constructor = ES5Element2;
 
-    const container = document.createElement('div');
-    container.innerHTML = '<es5-element-3></es5-element-3>';
-    const el = container.querySelector('es5-element-3');
-    assert.instanceOf(el, ES5Element3);
-    assert.instanceOf(el, HTMLElement);
-    assert.equal(el.tagName, 'ES5-ELEMENT-3');
-  });
+      customElements.define('es5-element-2', ES5Element2);
 
-  test('reactions', () => {
-    function ES5Element4() {
-      return HTMLElement.apply(this);
-    }
-    ES5Element4.prototype = Object.create(HTMLElement.prototype);
-    ES5Element4.prototype.constructor = ES5Element4;
-    ES5Element4.observedAttributes = ['test'];
-    ES5Element4.prototype.connectedCallback = function() {
-      this.connectedCalled = true;
-    };
-    ES5Element4.prototype.disconnectedCallback = function() {
-      this.disconnectedCalled = true;
-    };
-    ES5Element4.prototype.attributeChangedCallback = function(name, oldValue, newValue) {
-      this.attributeChangedCalled = `${name}, ${oldValue}, ${newValue}`;
-    };
-    ES5Element4.prototype.adoptedCallback = function() {
-      this.adoptedCalled = true;
-    };
+      const el = new ES5Element2();
+      assert.instanceOf(el, ES5Element2);
+      assert.instanceOf(el, HTMLElement);
+      assert.equal(el.tagName, 'ES5-ELEMENT-2');
+    });
 
-    customElements.define('es5-element-4', ES5Element4);
+    test('works with parser created elements', () => {
+      function ES5Element3() {
+        return HTMLElement.apply(this);
+      }
+      ES5Element3.prototype = Object.create(HTMLElement.prototype);
+      ES5Element3.prototype.constructor = ES5Element3;
 
-    const container = document.createElement('div');
-    document.body.appendChild(container);
+      customElements.define('es5-element-3', ES5Element3);
 
-    const el = new ES5Element4();
+      const container = document.createElement('div');
+      container.innerHTML = '<es5-element-3></es5-element-3>';
+      const el = container.querySelector('es5-element-3');
+      assert.instanceOf(el, ES5Element3);
+      assert.instanceOf(el, HTMLElement);
+      assert.equal(el.tagName, 'ES5-ELEMENT-3');
+    });
 
-    container.appendChild(el);
-    assert(el.connectedCalled);
-
-    container.removeChild(el);
-    assert(el.disconnectedCalled);
-
-    el.setAttribute('test', 'good');
-    assert.equal(el.attributeChangedCalled, 'test, null, good');
-
-    const doc = document.implementation.createHTMLDocument();
-    doc.adoptNode(el);
-    assert(el.adoptedCalled);
-
-  });
-
-});
-
-suite('Native Shim with ES5 + Reflect API super call (can be expected from transpilers)', () => {
-
-  suiteSetup(function() {
-    // Do nothing if the browser does not natively support custom elements.
-    if (!window.customElements) {
-      this.skip();
-      return;
-    }
-
-    // Do nothing if the browser does not support Reflect API.
-    if (typeof Reflect !== 'object' || typeof Reflect.construct !== 'function') {
-      this.skip();
-      return;
-    }
-  });
-
-  test('works with createElement()', () => {
-    function ES5ReflectElement1() {
-      return Reflect.construct(HTMLElement, [], this.constructor);
-    }
-    ES5ReflectElement1.prototype = Object.create(HTMLElement.prototype);
-    ES5ReflectElement1.prototype.constructor = ES5ReflectElement1;
-
-    customElements.define('es5-reflect-element-1', ES5ReflectElement1);
-
-    const el = document.createElement('es5-reflect-element-1');
-    assert.instanceOf(el, ES5ReflectElement1);
-    assert.instanceOf(el, HTMLElement);
-    assert.equal(el.tagName, 'ES5-REFLECT-ELEMENT-1');
-  });
-
-  test('works with user-called constructors', () => {
-    function ES5ReflectElement2() {
-      return Reflect.construct(HTMLElement, [], this.constructor);
-    }
-    ES5ReflectElement2.prototype = Object.create(HTMLElement.prototype);
-    ES5ReflectElement2.prototype.constructor = ES5ReflectElement2;
-
-    customElements.define('es5-reflect-element-2', ES5ReflectElement2);
-
-    const el = new ES5ReflectElement2();
-    assert.instanceOf(el, ES5ReflectElement2);
-    assert.instanceOf(el, HTMLElement);
-    assert.equal(el.tagName, 'ES5-REFLECT-ELEMENT-2');
-  });
-
-  test('works with parser created elements', () => {
-    function ES5ReflectElement3() {
-      return Reflect.construct(HTMLElement, [], this.constructor);
-    }
-    ES5ReflectElement3.prototype = Object.create(HTMLElement.prototype);
-    ES5ReflectElement3.prototype.constructor = ES5ReflectElement3;
-
-    customElements.define('es5-reflect-element-3', ES5ReflectElement3);
-
-    const container = document.createElement('div');
-    container.innerHTML = '<es5-reflect-element-3></es5-reflect-element-3>';
-    const el = container.querySelector('es5-reflect-element-3');
-    assert.instanceOf(el, ES5ReflectElement3);
-    assert.instanceOf(el, HTMLElement);
-    assert.equal(el.tagName, 'ES5-REFLECT-ELEMENT-3');
-  });
-
-  test('reactions', () => {
-    function ES5ReflectElement4() {
-      return Reflect.construct(HTMLElement, [], this.constructor);
-    }
-    ES5ReflectElement4.prototype = Object.create(HTMLElement.prototype);
-    ES5ReflectElement4.prototype.constructor = ES5ReflectElement4;
-    ES5ReflectElement4.observedAttributes = ['test'];
-    ES5ReflectElement4.prototype.connectedCallback = function() {
-      this.connectedCalled = true;
-    };
-    ES5ReflectElement4.prototype.disconnectedCallback = function() {
-      this.disconnectedCalled = true;
-    };
-    ES5ReflectElement4.prototype.attributeChangedCallback = function(name, oldValue, newValue) {
-      this.attributeChangedCalled = `${name}, ${oldValue}, ${newValue}`;
-    };
-    ES5ReflectElement4.prototype.adoptedCallback = function() {
-      this.adoptedCalled = true;
-    };
-
-    customElements.define('es5-reflect-element-4', ES5ReflectElement4);
-
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-
-    const el = new ES5ReflectElement4();
-
-    container.appendChild(el);
-    assert(el.connectedCalled);
-
-    container.removeChild(el);
-    assert(el.disconnectedCalled);
-
-    el.setAttribute('test', 'good');
-    assert.equal(el.attributeChangedCalled, 'test, null, good');
-
-    const doc = document.implementation.createHTMLDocument();
-    doc.adoptNode(el);
-    assert(el.adoptedCalled);
-
-  });
-});
-
-suite('Native Shim with ES6 classes', () => {
-
-  suiteSetup(function() {
-    // Do nothing if the browser does not natively support custom elements.
-    if (!window.customElements) {
-      this.skip();
-      return;
-    }
-  });
-
-  test('works with createElement()', () => {
-    class ES6Element1 extends HTMLElement {}
-    customElements.define('es6-element-1', ES6Element1);
-
-    const el = document.createElement('es6-element-1');
-    assert.instanceOf(el, ES6Element1);
-    assert.instanceOf(el, HTMLElement);
-    assert.equal(el.tagName, 'ES6-ELEMENT-1');
-  });
-
-  test('works with user-called constructors', () => {
-    class ES6Element2 extends HTMLElement {}
-    customElements.define('es6-element-2', ES6Element2);
-
-    const el = new ES6Element2();
-    assert.instanceOf(el, ES6Element2);
-    assert.instanceOf(el, HTMLElement);
-    assert.equal(el.tagName, 'ES6-ELEMENT-2');
-  });
-
-  test('works with parser created elements', () => {
-    class ES6Element3 extends HTMLElement {}
-    customElements.define('es6-element-3', ES6Element3);
-
-    const container = document.createElement('div');
-    container.innerHTML = '<es6-element-3></es6-element-3>';
-    const el = container.querySelector('es6-element-3');
-    assert.instanceOf(el, ES6Element3);
-    assert.instanceOf(el, HTMLElement);
-    assert.equal(el.tagName, 'ES6-ELEMENT-3');
-  });
-
-  test('reactions', () => {
-    class ES6Element4 extends HTMLElement {
-      static get observedAttributes() { return ['test']; }
-
-      connectedCallback() {
+    test('reactions', () => {
+      function ES5Element4() {
+        return HTMLElement.apply(this);
+      }
+      ES5Element4.prototype = Object.create(HTMLElement.prototype);
+      ES5Element4.prototype.constructor = ES5Element4;
+      ES5Element4.observedAttributes = ['test'];
+      ES5Element4.prototype.connectedCallback = function() {
         this.connectedCalled = true;
-      }
-
-      disconnectedCallback() {
+      };
+      ES5Element4.prototype.disconnectedCallback = function() {
         this.disconnectedCalled = true;
-      }
-
-      attributeChangedCallback(name, oldValue, newValue) {
+      };
+      ES5Element4.prototype.attributeChangedCallback = function(name, oldValue, newValue) {
         this.attributeChangedCalled = `${name}, ${oldValue}, ${newValue}`;
-      }
-
-      adoptedCallback() {
+      };
+      ES5Element4.prototype.adoptedCallback = function() {
         this.adoptedCalled = true;
+      };
+
+      customElements.define('es5-element-4', ES5Element4);
+
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      const el = new ES5Element4();
+
+      container.appendChild(el);
+      assert(el.connectedCalled);
+
+      container.removeChild(el);
+      assert(el.disconnectedCalled);
+
+      el.setAttribute('test', 'good');
+      assert.equal(el.attributeChangedCalled, 'test, null, good');
+
+      const doc = document.implementation.createHTMLDocument();
+      doc.adoptNode(el);
+      assert(el.adoptedCalled);
+
+    });
+
+  });
+
+  suite('Extending HTMLElement with ES5 + Reflect API super call (can be expected from transpilers)', () => {
+
+    suiteSetup(function() {
+      // Do nothing if the browser does not support Reflect API.
+      if (typeof Reflect !== 'object' || typeof Reflect.construct !== 'function') {
+        this.skip();
+        return;
       }
-    }
+    });
 
-    customElements.define('es6-element-4', ES6Element4);
+    test('works with createElement()', () => {
+      function ES5ReflectElement1() {
+        return Reflect.construct(HTMLElement, [], this.constructor);
+      }
+      ES5ReflectElement1.prototype = Object.create(HTMLElement.prototype);
+      ES5ReflectElement1.prototype.constructor = ES5ReflectElement1;
 
-    const container = document.createElement('div');
-    document.body.appendChild(container);
+      customElements.define('es5-reflect-element-1', ES5ReflectElement1);
 
-    const el = new ES6Element4();
+      const el = document.createElement('es5-reflect-element-1');
+      assert.instanceOf(el, ES5ReflectElement1);
+      assert.instanceOf(el, HTMLElement);
+      assert.equal(el.tagName, 'ES5-REFLECT-ELEMENT-1');
+    });
 
-    container.appendChild(el);
-    assert(el.connectedCalled);
+    test('works with user-called constructors', () => {
+      function ES5ReflectElement2() {
+        return Reflect.construct(HTMLElement, [], this.constructor);
+      }
+      ES5ReflectElement2.prototype = Object.create(HTMLElement.prototype);
+      ES5ReflectElement2.prototype.constructor = ES5ReflectElement2;
 
-    container.removeChild(el);
-    assert(el.disconnectedCalled);
+      customElements.define('es5-reflect-element-2', ES5ReflectElement2);
 
-    el.setAttribute('test', 'good');
-    assert.equal(el.attributeChangedCalled, 'test, null, good');
+      const el = new ES5ReflectElement2();
+      assert.instanceOf(el, ES5ReflectElement2);
+      assert.instanceOf(el, HTMLElement);
+      assert.equal(el.tagName, 'ES5-REFLECT-ELEMENT-2');
+    });
 
-    const doc = document.implementation.createHTMLDocument();
-    doc.adoptNode(el);
-    assert(el.adoptedCalled);
+    test('works with parser created elements', () => {
+      function ES5ReflectElement3() {
+        return Reflect.construct(HTMLElement, [], this.constructor);
+      }
+      ES5ReflectElement3.prototype = Object.create(HTMLElement.prototype);
+      ES5ReflectElement3.prototype.constructor = ES5ReflectElement3;
+
+      customElements.define('es5-reflect-element-3', ES5ReflectElement3);
+
+      const container = document.createElement('div');
+      container.innerHTML = '<es5-reflect-element-3></es5-reflect-element-3>';
+      const el = container.querySelector('es5-reflect-element-3');
+      assert.instanceOf(el, ES5ReflectElement3);
+      assert.instanceOf(el, HTMLElement);
+      assert.equal(el.tagName, 'ES5-REFLECT-ELEMENT-3');
+    });
+
+    test('reactions', () => {
+      function ES5ReflectElement4() {
+        return Reflect.construct(HTMLElement, [], this.constructor);
+      }
+      ES5ReflectElement4.prototype = Object.create(HTMLElement.prototype);
+      ES5ReflectElement4.prototype.constructor = ES5ReflectElement4;
+      ES5ReflectElement4.observedAttributes = ['test'];
+      ES5ReflectElement4.prototype.connectedCallback = function() {
+        this.connectedCalled = true;
+      };
+      ES5ReflectElement4.prototype.disconnectedCallback = function() {
+        this.disconnectedCalled = true;
+      };
+      ES5ReflectElement4.prototype.attributeChangedCallback = function(name, oldValue, newValue) {
+        this.attributeChangedCalled = `${name}, ${oldValue}, ${newValue}`;
+      };
+      ES5ReflectElement4.prototype.adoptedCallback = function() {
+        this.adoptedCalled = true;
+      };
+
+      customElements.define('es5-reflect-element-4', ES5ReflectElement4);
+
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      const el = new ES5ReflectElement4();
+
+      container.appendChild(el);
+      assert(el.connectedCalled);
+
+      container.removeChild(el);
+      assert(el.disconnectedCalled);
+
+      el.setAttribute('test', 'good');
+      assert.equal(el.attributeChangedCalled, 'test, null, good');
+
+      const doc = document.implementation.createHTMLDocument();
+      doc.adoptNode(el);
+      assert(el.adoptedCalled);
+
+    });
+  });
+
+  suite('Extending HTMLElement with ES6 classes', () => {
+
+    test('works with createElement()', () => {
+      class ES6Element1 extends HTMLElement {}
+      customElements.define('es6-element-1', ES6Element1);
+
+      const el = document.createElement('es6-element-1');
+      assert.instanceOf(el, ES6Element1);
+      assert.instanceOf(el, HTMLElement);
+      assert.equal(el.tagName, 'ES6-ELEMENT-1');
+    });
+
+    test('works with user-called constructors', () => {
+      class ES6Element2 extends HTMLElement {}
+      customElements.define('es6-element-2', ES6Element2);
+
+      const el = new ES6Element2();
+      assert.instanceOf(el, ES6Element2);
+      assert.instanceOf(el, HTMLElement);
+      assert.equal(el.tagName, 'ES6-ELEMENT-2');
+    });
+
+    test('works with parser created elements', () => {
+      class ES6Element3 extends HTMLElement {}
+      customElements.define('es6-element-3', ES6Element3);
+
+      const container = document.createElement('div');
+      container.innerHTML = '<es6-element-3></es6-element-3>';
+      const el = container.querySelector('es6-element-3');
+      assert.instanceOf(el, ES6Element3);
+      assert.instanceOf(el, HTMLElement);
+      assert.equal(el.tagName, 'ES6-ELEMENT-3');
+    });
+
+    test('reactions', () => {
+      class ES6Element4 extends HTMLElement {
+        static get observedAttributes() { return ['test']; }
+
+        connectedCallback() {
+          this.connectedCalled = true;
+        }
+
+        disconnectedCallback() {
+          this.disconnectedCalled = true;
+        }
+
+        attributeChangedCallback(name, oldValue, newValue) {
+          this.attributeChangedCalled = `${name}, ${oldValue}, ${newValue}`;
+        }
+
+        adoptedCallback() {
+          this.adoptedCalled = true;
+        }
+      }
+
+      customElements.define('es6-element-4', ES6Element4);
+
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      const el = new ES6Element4();
+
+      container.appendChild(el);
+      assert(el.connectedCalled);
+
+      container.removeChild(el);
+      assert(el.disconnectedCalled);
+
+      el.setAttribute('test', 'good');
+      assert.equal(el.attributeChangedCalled, 'test, null, good');
+
+      const doc = document.implementation.createHTMLDocument();
+      doc.adoptNode(el);
+      assert(el.adoptedCalled);
+
+    });
 
   });
 


### PR DESCRIPTION
I nested all of the other tests in that group; the whitespace-ignoring diff is much cleaner.