### PR TITLE
Trigger attribute-changed-callback for different attribute capitalization

### DIFF
--- a/src/Patch/Element.js
+++ b/src/Patch/Element.js
@@ -132,7 +132,7 @@ export default function(internals) {
       const oldValue = Native.Element_getAttribute.call(this, name);
       Native.Element_setAttribute.call(this, name, newValue);
       newValue = Native.Element_getAttribute.call(this, name);
-      internals.attributeChangedCallback(this, name, oldValue, newValue, null);
+      internals.attributeChangedCallback(this, name.toLowerCase(), oldValue, newValue, null);
     });
 
   Utilities.setPropertyUnchecked(Element.prototype, 'setAttributeNS',
@@ -168,7 +168,7 @@ export default function(internals) {
       const oldValue = Native.Element_getAttribute.call(this, name);
       Native.Element_removeAttribute.call(this, name);
       if (oldValue !== null) {
-        internals.attributeChangedCallback(this, name, oldValue, null, null);
+        internals.attributeChangedCallback(this, name.toLowerCase(), oldValue, null, null);
       }
     });
 

--- a/tests/html/Element/removeAttribute.html
+++ b/tests/html/Element/removeAttribute.html
@@ -97,6 +97,21 @@ suite('Removing a set attribute.', function() {
     assert.equal(element.attrCallbackArgs.length, 2);
     assert.deepEqual(element.attrCallbackArgs[1], ['attr', 'abc', null, null]);
   });
+
+  test('Removing an observed attribute with a different capitalization triggers a callback.', function() {
+    const element = document.createElement(localName2);
+
+    assert.equal(element.attrCallbackArgs.length, 0);
+
+    element.setAttribute('attr', 'abc');
+
+    assert.equal(element.attrCallbackArgs.length, 1);
+
+    element.removeAttribute('Attr');
+
+    assert.equal(element.attrCallbackArgs.length, 2);
+    assert.deepEqual(element.attrCallbackArgs[1], ['attr', 'abc', null, null]);
+  });
 });
 </script>
 </body>

--- a/tests/html/Element/removeAttributeNS.html
+++ b/tests/html/Element/removeAttributeNS.html
@@ -102,6 +102,20 @@ suite('Removing a set attribute.', function() {
     assert.equal(element.attrCallbackArgs.length, 2);
     assert.deepEqual(element.attrCallbackArgs[1], ['attr', 'abc', NON_EXISTANT_VALUE, 'ns']);
   });
+
+  test('Removing an observed attribute with a different capitalization does not trigger a callback.', function() {
+    const element = document.createElement(localName2);
+
+    assert.equal(element.attrCallbackArgs.length, 0);
+
+    element.setAttributeNS('ns', 'attr', 'abc');
+
+    assert.equal(element.attrCallbackArgs.length, 1);
+
+    element.removeAttribute('ns', 'Attr');
+
+    assert.equal(element.attrCallbackArgs.length, 1);
+  });
 });
 </script>
 </body>

--- a/tests/html/Element/setAttribute.html
+++ b/tests/html/Element/setAttribute.html
@@ -111,8 +111,23 @@ suite('Changing previously set values.', function() {
     assert.equal(element.attrCallbackArgs.length, 2);
     assert.deepEqual(element.attrCallbackArgs[1], ['attr', 'abc', 'def', null]);
   });
+
+  test('Setting an observed attribute with a different capitalization triggers a callback', function() {
+    const element = document.createElement(localName);
+
+    assert.equal(element.attrCallbackArgs.length, 0);
+
+    element.setAttribute('Attr', 'abc');
+
+    assert.equal(element.attrCallbackArgs.length, 1);
+    assert.deepEqual(element.attrCallbackArgs[0], ['attr', null, 'abc', null]);
+
+    element.setAttribute('attR', 'def');
+
+    assert.equal(element.attrCallbackArgs.length, 2);
+    assert.deepEqual(element.attrCallbackArgs[1], ['attr', 'abc', 'def', null]);
+  });
 });
 </script>
 </body>
 </html>
-

--- a/tests/html/Element/setAttributeNS.html
+++ b/tests/html/Element/setAttributeNS.html
@@ -117,6 +117,20 @@ suite('Changing previously set values.', function() {
     assert.equal(element.attrCallbackArgs.length, 2);
     assert.deepEqual(element.attrCallbackArgs[1], ['attr', 'abc', 'def', 'ns']);
   });
+
+  test('Setting an observed attribute with a different capitalization does not trigger a callback.', function() {
+    const element = document.createElement(localName);
+
+    assert.equal(element.attrCallbackArgs.length, 0);
+
+    element.setAttributeNS('ns', 'Attr', 'abc');
+
+    assert.equal(element.attrCallbackArgs.length, 0);
+
+    element.setAttributeNS('ns', 'attR', 'def');
+
+    assert.equal(element.attrCallbackArgs.length, 0);
+  });
 });
 </script>
 </body>


### PR DESCRIPTION
This patches `setAttribute` and `removeAttribute` to lowercase when setting attributes. I have confirmed with the implementation in Chrome that `setAttributeNS` and remove alike do NOT trigger the callback with different capitalization.

Fixes #167 