### PR TITLE
Remove duplicate CustomElementState enum in externs

### DIFF
--- a/externs/custom-elements.js
+++ b/externs/custom-elements.js
@@ -15,14 +15,6 @@ CustomElementRegistry.prototype.forcePolyfill;
 class AlreadyConstructedMarkerType {}
 
 /**
- * @enum {number}
- */
-const CustomElementState = {
-  custom: 1,
-  failed: 2,
-};
-
-/**
  * @typedef {{
  *  localName: string,
  *  constructorFunction: !Function,
@@ -62,7 +54,7 @@ Node.prototype.readyState;
 
 // Apply generally to Element.
 
-/** @type {!CustomElementState|undefined} */
+/** @type {number|undefined} */
 Element.prototype.__CE_state;
 
 /** @type {!CustomElementDefinition|undefined} */


### PR DESCRIPTION
A recent change to Closure JS Compiler surfaced this as an error, since we already have a typed called CustomElementState defined in the code itself, and when assigning from one to the other, a new type error was being produced.