### PR TITLE
An exported variable can not be private

### DIFF
--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -30,7 +30,6 @@ export function isValidCustomElementName(localName) {
 }
 
 /**
- * @private
  * @param {!Node} node
  * @return {boolean}
  */


### PR DESCRIPTION
Currently this has no meaning, but closure compiler will soon make this an error.