### PR TITLE
Check that polyfillWrapFlushCallback is truthy

### DIFF
--- a/src/native-shim.js
+++ b/src/native-shim.js
@@ -22,7 +22,7 @@
     window.customElements === undefined ||
     // The webcomponentsjs custom elements polyfill doesn't require
     // ES2015-compatible construction (`super()` or `Reflect.construct`).
-    window.customElements.hasOwnProperty('polyfillWrapFlushCallback')
+    window.customElements.polyfillWrapFlushCallback
   ) {
     return;
   }


### PR DESCRIPTION
We shouldn't check that it's an own property of customElements because it never will be. The polyfill defines a CustomElementsRegistry class with an instance method named polyfillWrapFlushCallback. That instance method won't be an own property of instances of CustomElementsRegistry. Simple snippet to verify:

```javascript
{
  class Foo { bar() {} };
  const foo = new Foo();
  console.log(`foo.bar exists: ${!!foo.bar}`);
  console.log(`foo has an own property of bar: ${foo.hasOwnProperty('bar')}`);
}
```