### PR TITLE
Do not create new text node for values of null|undefined|''. Fixes #190.

### DIFF
--- a/src/Patch/Node.js
+++ b/src/Patch/Node.js
@@ -237,7 +237,11 @@ export default function(internals) {
           while (this.firstChild) {
             Native.Node_removeChild.call(this, this.firstChild);
           }
-          Native.Node_appendChild.call(this, document.createTextNode(assignedValue));
+          // `textContent = null | undefined | ''` does not result in
+          // a TextNode childNode
+          if (assignedValue != null && assignedValue !== '') {
+            Native.Node_appendChild.call(this, document.createTextNode(assignedValue));
+          }
         },
       });
     });

--- a/tests/html/Node/textContent.html
+++ b/tests/html/Node/textContent.html
@@ -104,6 +104,26 @@ suite('Custom element descendants of the context element are disconnected when s
 
     document.body.removeChild(div);
   });
+
+  test('textContent API corner cases', function() {
+    div.textContent = 'textNode';
+    assert.equal(div.childNodes.length, 1);
+    // Setting textContent to empty string should result in no node
+    div.textContent = '';
+    assert.equal(div.childNodes.length, 0);
+
+    div.textContent = 'textNode';
+    assert.equal(div.childNodes.length, 1);
+    // Setting textContent to `undefined` should result in no node
+    div.textContent = undefined;
+    assert.equal(div.childNodes.length, 0);
+
+    div.textContent = 'textNode';
+    assert.equal(div.childNodes.length, 1);
+    // Setting textContent to `null` should result in no node
+    div.textContent = null;
+    assert.equal(div.childNodes.length, 0);
+  });
 });
 </script>
 </body>

--- a/tests/html/Node/textContent.html
+++ b/tests/html/Node/textContent.html
@@ -114,15 +114,20 @@ suite('Custom element descendants of the context element are disconnected when s
 
     div.textContent = 'textNode';
     assert.equal(div.childNodes.length, 1);
-    // Setting textContent to `undefined` should result in no node
-    div.textContent = undefined;
-    assert.equal(div.childNodes.length, 0);
-
-    div.textContent = 'textNode';
-    assert.equal(div.childNodes.length, 1);
     // Setting textContent to `null` should result in no node
     div.textContent = null;
     assert.equal(div.childNodes.length, 0);
+
+    // Edge's native textContent creates a text node with 'undefined' in
+    // it; the spec seems ambiguous
+    if (!navigator.userAgent.match(/Edge/)) {
+      div.textContent = 'textNode';
+      assert.equal(div.childNodes.length, 1);
+      // Setting textContent to `undefined` should result in no node (?)
+      div.textContent = undefined;
+      assert.equal(div.childNodes.length, 0);
+    }
+
   });
 });
 </script>

--- a/tests/html/Node/textContent.html
+++ b/tests/html/Node/textContent.html
@@ -120,7 +120,7 @@ suite('Custom element descendants of the context element are disconnected when s
 
     // Edge's native textContent creates a text node with 'undefined' in
     // it; the spec seems ambiguous
-    if (!navigator.userAgent.match(/Edge/)) {
+    if (!navigator.userAgent.match(/Trident|Edge/)) {
       div.textContent = 'textNode';
       assert.equal(div.childNodes.length, 1);
       // Setting textContent to `undefined` should result in no node (?)


### PR DESCRIPTION
Fixes #190.