### PR TITLE
Preserve HTMLElement function name from jscompiler

### DIFF
--- a/src/native-shim.js
+++ b/src/native-shim.js
@@ -27,10 +27,19 @@
     return;
   }
   const BuiltInHTMLElement = HTMLElement;
-  window.HTMLElement = /** @this {!Object} */ function HTMLElement() {
-    return Reflect.construct(
-        BuiltInHTMLElement, [], /** @type {!Function} */ (this.constructor));
+  /**
+   * With jscompiler's RECOMMENDED_FLAGS the function name will be optimized away.
+   * However, if we declare the function as a property on an object literal, and
+   * use quotes for the property name, then closure will leave that much intact,
+   * which is enough for the JS VM to correctly set Function.prototype.name.
+   */
+  const wrapperForTheName = {
+    'HTMLElement': /** @this {!Object} */ function HTMLElement() {
+      return Reflect.construct(
+          BuiltInHTMLElement, [], /** @type {!Function} */ (this.constructor));
+    }
   };
+  window.HTMLElement = wrapperForTheName['HTMLElement'];
   HTMLElement.prototype = BuiltInHTMLElement.prototype;
   HTMLElement.prototype.constructor = HTMLElement;
   Object.setPrototypeOf(HTMLElement, BuiltInHTMLElement);


### PR DESCRIPTION
This is a more comprehensive strategy to preserve the function name in the face of Closure compiler's optimizations.

Function.prototype.name will be inferred not only from the name give in the function expression/declaration itself, but also in the case of a function expression that's initializing a variable or property, it can be inferred to that variable or property name. Since closure compiler is free to remove the function name itself, but it isn't free to remove or rename a quoted property, we use that strategy here.