### PR TITLE
Prevent double-installation of es5 shim

### DIFF
--- a/externs/custom-elements.js
+++ b/externs/custom-elements.js
@@ -62,3 +62,6 @@ Element.prototype.__CE_definition;
 
 /** @type {!DocumentFragment|undefined} */
 Element.prototype.__CE_shadowRoot;
+
+/** @type {boolean} */
+HTMLElement.es5Shimmed;

--- a/src/native-shim.js
+++ b/src/native-shim.js
@@ -16,13 +16,15 @@
  */
 (function() {
   if (
+    // An es5 shim is already loaded, don't load again.
+    HTMLElement.es5Shimmed ||
     // No Reflect, no classes, no need for shim because native custom elements
     // require ES2015 classes or Reflect.
     window.Reflect === undefined ||
     window.customElements === undefined ||
     // The webcomponentsjs custom elements polyfill doesn't require
     // ES2015-compatible construction (`super()` or `Reflect.construct`).
-    window.customElements.polyfillWrapFlushCallback
+    window.customElements['polyfillWrapFlushCallback']
   ) {
     return;
   }
@@ -33,5 +35,6 @@
   };
   HTMLElement.prototype = BuiltInHTMLElement.prototype;
   HTMLElement.prototype.constructor = HTMLElement;
+  HTMLElement.es5Shimmed = true;
   Object.setPrototypeOf(HTMLElement, BuiltInHTMLElement);
 })();


### PR DESCRIPTION
This may be more of an issue inside google due to the way that we've piped things through the build system, but this patch will ensure that even if the ES5 native shim is included in the page more than once, it is only installed once.

It's possible this is unnecessary in the wider world, in which case we can keep it as a downstream patch.