### PR TITLE
Compile the native shim; fix `HTMLElement.name`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 
 npm-debug.log*
 custom-elements.min.js*
+native-shim.min.js*

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,23 +16,34 @@ const sourcemaps = require('gulp-sourcemaps');
 
 const closureCompiler = compilerPackage.gulp();
 
-gulp.task('default', () => {
+const gulpTask = (closureOptions = {}) => {
   return gulp.src('./src/**/*.js', {base: './'})
     .pipe(sourcemaps.init())
-    .pipe(closureCompiler({
+    .pipe(closureCompiler(Object.assign({
       compilation_level: 'ADVANCED',
       warning_level: 'VERBOSE',
       language_in: 'ECMASCRIPT6_STRICT',
-      language_out: 'ECMASCRIPT5_STRICT',
       externs: ['externs/custom-elements.js'],
       dependency_mode: 'STRICT',
-      entry_point: ['/src/custom-elements'],
-      js_output_file: 'custom-elements.min.js',
       output_wrapper: '(function(){\n%output%\n}).call(self);',
       assume_function_wrapper: true,
       new_type_inf: true,
       rewrite_polyfills: false,
-    }))
-    .pipe(sourcemaps.write('/'))
+    }, closureOptions)))
+    .pipe(sourcemaps.write('./'))
     .pipe(gulp.dest('./'));
+};
+
+const buildPolyfill = () => gulpTask({
+  entry_point: ['/src/custom-elements'],
+  js_output_file: 'custom-elements.min.js',
+  language_out: 'ECMASCRIPT5_STRICT',
 });
+
+const buildNativeShim = () => gulpTask({
+  entry_point: ['/src/native-shim'],
+  js_output_file: 'native-shim.min.js',
+  language_out: 'ECMASCRIPT6_STRICT',
+});
+
+gulp.task('default', gulp.series(buildPolyfill, buildNativeShim));

--- a/package-lock.json
+++ b/package-lock.json
@@ -4466,7 +4466,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4487,12 +4488,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4507,17 +4510,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4634,7 +4640,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4646,6 +4653,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4660,6 +4668,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4667,12 +4676,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4691,6 +4702,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4771,7 +4783,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4783,6 +4796,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4868,7 +4882,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4904,6 +4919,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4923,6 +4939,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4966,12 +4983,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8881,7 +8900,8 @@
           "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8951,7 +8971,8 @@
           "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minimist": {
           "version": "1.2.0",

--- a/src/native-shim.js
+++ b/src/native-shim.js
@@ -26,20 +26,20 @@
   ) {
     return;
   }
-  const BuiltInHTMLElement = HTMLElement;
+  const BuiltInHTMLElement = window.HTMLElement;
   /**
    * With jscompiler's RECOMMENDED_FLAGS the function name will be optimized away.
    * However, if we declare the function as a property on an object literal, and
    * use quotes for the property name, then closure will leave that much intact,
    * which is enough for the JS VM to correctly set Function.prototype.name.
    */
-  const wrapperForTheName = {
+  Object.assign(window, {
     'HTMLElement': /** @this {!Object} */ function HTMLElement() {
       return Reflect.construct(
           BuiltInHTMLElement, [], /** @type {!Function} */ (this.constructor));
-    }
-  };
-  window.HTMLElement = wrapperForTheName['HTMLElement'];
+    },
+  });
+  const HTMLElement = window.HTMLElement;
   HTMLElement.prototype = BuiltInHTMLElement.prototype;
   HTMLElement.prototype.constructor = HTMLElement;
   Object.setPrototypeOf(HTMLElement, BuiltInHTMLElement);

--- a/tests/html/shim.html
+++ b/tests/html/shim.html
@@ -10,7 +10,7 @@
 -->
 <title>Custom Elements Tests</title>
 <meta charset="utf-8">
-<script src="../../src/native-shim.js"></script>
+<script src="../../native-shim.min.js"></script>
 <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 
 <script>


### PR DESCRIPTION
Closure Compiler seems to be removing the temporary object added in #193 that we need to make sure that `HTMLElement` continues to have the right `.name`. This PR uses `Object.assign` to assign `HTMLElement` to the window so that Closure Compiler can't remove the object.

cc @rictic