### PR TITLE
Optimizations for creating/connecting elements

### DIFF
--- a/src/CustomElementInternals.js
+++ b/src/CustomElementInternals.js
@@ -212,7 +212,7 @@ export default class CustomElementInternals {
    * }=} options
    */
   patchAndUpgradeTree(root, options = {}) {
-    const visitedImports = options.visitedImports || new Set();
+    const visitedImports = options.visitedImports;
     const upgrade = options.upgrade || (element => this.upgradeElement(element));
 
     const elements = [];
@@ -317,7 +317,8 @@ export default class CustomElementInternals {
     element.__CE_state = CEState.custom;
     element.__CE_definition = definition;
 
-    if (definition.attributeChangedCallback) {
+    // Check `hasAttributes` here to avoid iterating when it's not necessary.
+    if (definition.attributeChangedCallback && element.hasAttributes()) {
       const observedAttributes = definition.observedAttributes;
       for (let i = 0; i < observedAttributes.length; i++) {
         const name = observedAttributes[i];

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -29,10 +29,9 @@ export function isValidCustomElementName(localName) {
   return !reserved && validForm;
 }
 
-// IE11 does not have document.contains so polyfill it.
-if (!document.contains) {
-  document.contains = (node) => document.documentElement.contains(node);
-}
+// Note, IE11 doesn't have `document.contains`.
+const nativeContains = document.contains ? document.contains.bind(document) :
+  document.documentElement.contains.bind(document.documentElement);
 
 /**
  * @param {!Node} node
@@ -46,7 +45,7 @@ export function isConnected(node) {
   }
   // Optimization: It's significantly faster here to try to use `contains`,
   // especially on Edge/IE/
-  if (document.contains(node)) {
+  if (nativeContains(node)) {
     return true;
   }
   /** @type {?Node|undefined} */
@@ -82,7 +81,7 @@ function nextNode(root, start) {
 /**
  * @param {!Node} root
  * @param {!function(!Element)} callback
- * @param {?Set<Node>} visitedImports
+ * @param {!Set<!Node>=} visitedImports
  */
 export function walkDeepDescendantElements(root, callback, visitedImports) {
   let node = root;


### PR DESCRIPTION
* When computing if an element isConntected, try to use `document.contains` before walking the dom tree. This is significantly faster, especially on Edge/IE.

* When an element is upgraded, check `hasAttributes` before iterating observedAttributes.

* When walking elements, create the Set of traversed imports lazily.