### PR TITLE
Fix the `ChildNode#after` patching condition.

### DIFF
--- a/src/Patch/Interface/ChildNode.js
+++ b/src/Patch/Interface/ChildNode.js
@@ -82,7 +82,7 @@ export default function(internals, destination, builtIn) {
     Utilities.setPropertyUnchecked(destination, 'before', beforeAfterPatch(builtIn.before));
   }
 
-  if (builtIn.before !== undefined) {
+  if (builtIn.after !== undefined) {
     Utilities.setPropertyUnchecked(destination, 'after', beforeAfterPatch(builtIn.after));
   }
 


### PR DESCRIPTION
Currently, `ChildNode#after` is patched when a native version of `ChildNode#before` exists.