### PR TITLE
Adds `customElements.polyfillDefineLazy` and `preferPerformance`

### DIFF
--- a/externs/custom-elements.js
+++ b/externs/custom-elements.js
@@ -12,6 +12,9 @@
 /** @type {boolean|undefined} */
 CustomElementRegistry.prototype.forcePolyfill;
 
+/** @type {function(string, !Function)|undefined} */
+CustomElementRegistry.prototype.lazyDefine;
+
 class AlreadyConstructedMarkerType {}
 
 /**

--- a/externs/custom-elements.js
+++ b/externs/custom-elements.js
@@ -16,7 +16,7 @@ CustomElementRegistry.prototype.forcePolyfill;
 CustomElementRegistry.prototype.preferPerformance;
 
 /** @type {function(string, !Function)|undefined} */
-CustomElementRegistry.prototype.lazyDefine;
+CustomElementRegistry.prototype.polyfillDefineLazy;
 
 class AlreadyConstructedMarkerType {}
 
@@ -33,6 +33,14 @@ class AlreadyConstructedMarkerType {}
  * }}
  */
 let CustomElementDefinition;
+
+/**
+ * @typedef {{
+ *  localName: string,
+ *  constructorGenerator: !Function
+ * }}
+ */
+let CustomElementLazyDefinition;
 
 
 // These properties are defined in the closure externs so that they will not be

--- a/externs/custom-elements.js
+++ b/externs/custom-elements.js
@@ -12,6 +12,9 @@
 /** @type {boolean|undefined} */
 CustomElementRegistry.prototype.forcePolyfill;
 
+/** @type {boolean|undefined} */
+CustomElementRegistry.prototype.preferPerformance;
+
 /** @type {function(string, !Function)|undefined} */
 CustomElementRegistry.prototype.lazyDefine;
 

--- a/src/CustomElementInternals.js
+++ b/src/CustomElementInternals.js
@@ -9,12 +9,41 @@
  */
 
 import * as Utilities from './Utilities.js';
+import Deferred from './Deferred.js';
 import CEState from './CustomElementState.js';
+
+const PENDING_LAZY_DEFINITION = {};
 
 export default class CustomElementInternals {
   constructor(preferPerformance) {
+    /**
+     * @private
+     * @type {!Map<string, !Deferred<undefined>>}
+     */
+    this._whenDefinedDeferred = new Map();
+
+    /**
+     * The default flush callback triggers the document walk synchronously.
+     * @type {!Function}
+     */
+    this.flushCallback = fn => fn();
+
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this._flushPending = false;
+
+    /**
+     * @private
+     * @type {!Array<!CustomElementDefinition|CustomElementLazyDefinition>}
+     */
+    this._pendingDefinitions = [];
+
     /** @type {!Map<string, !CustomElementDefinition>} */
     this._localNameToDefinition = new Map();
+
+    this._localNameToLazyDefinition = new Map();
 
     /** @type {!Map<!Function, !CustomElementDefinition>} */
     this._constructorToDefinition = new Map();
@@ -29,7 +58,7 @@ export default class CustomElementInternals {
     this._hasPatches = false;
 
     /** @type {boolean} */
-    this._elementDefinitionIsRunning = false;
+    this.elementDefinitionIsRunning = false;
 
     /** @type {boolean} */
     this.preferPerformance = preferPerformance || false;
@@ -37,23 +66,16 @@ export default class CustomElementInternals {
 
   /**
    * @param {string} localName
-   * @param {!CustomElementDefinition} definition
-   */
-  setDefinition(localName, definition) {
-    this._localNameToDefinition.set(localName, definition);
-    this._constructorToDefinition.set(definition.constructorFunction, definition);
-  }
-
-  /**
-   * @param {string} localName
    * @param {!Function} constructor
    */
-  createDefinition(localName, constructor) {
+  setupDefinition(localName, constructor) {
+    this.elementDefinitionIsRunning = true;
     let connectedCallback;
     let disconnectedCallback;
     let adoptedCallback;
     let attributeChangedCallback;
     let observedAttributes;
+    let errorGettingCallbacks = false;
     try {
       /** @type {!Object} */
       const prototype = constructor.prototype;
@@ -75,10 +97,14 @@ export default class CustomElementInternals {
       attributeChangedCallback = getCallback('attributeChangedCallback');
       observedAttributes = constructor['observedAttributes'] || [];
     } catch (e) {
+      errorGettingCallbacks = true;
+    }
+    this.elementDefinitionIsRunning = false;
+    if (errorGettingCallbacks) {
       return;
     }
 
-    return {
+    const definition = {
       localName,
       constructorFunction: constructor,
       connectedCallback,
@@ -86,22 +112,165 @@ export default class CustomElementInternals {
       adoptedCallback,
       attributeChangedCallback,
       observedAttributes,
-      constructionStack: [],
-      isClassGenerator: false
+      constructionStack: []
     };
+
+    this.setDefinition(localName, definition);
+
+    return definition;
   }
 
-  ensureDefinitionGenerated(definition) {
-    // Reify definition if it is a class generator.
-    if (definition.isClassGenerator) {
-      this._elementDefinitionIsRunning = true;
-      const localName = definition.localName;
-      const constructor = definition();
-      definition = this.createDefinition(localName, constructor);
-      this._elementDefinitionIsRunning = false;
-      this.setDefinition(localName, definition);
-    }
+  /**
+   * @param {string} localName
+   * @param {!CustomElementDefinition} definition
+   */
+  setDefinition(localName, definition) {
+    this._localNameToDefinition.set(localName, definition);
+    this._constructorToDefinition.set(definition.constructorFunction, definition);
+  }
+
+  /**
+   * @param {string} localName
+   * @param {!Function} constructorGenerator
+   */
+  setupLazyDefinition(localName, constructorGenerator) {
+    const definition = {
+      localName,
+      constructorGenerator
+    };
+    this.setLazyDefinition(localName, definition);
     return definition;
+  }
+
+  /**
+   * @param {string} localName
+   * @param {!Function|undefined|Object} lazyDefinition
+   */
+  setLazyDefinition(localName, lazyDefinition) {
+    this._localNameToLazyDefinition.set(localName, lazyDefinition);
+  }
+
+  processDefinition(definition) {
+    this._pendingDefinitions.push(definition);
+
+    // If we've already called the flush callback and it hasn't called back yet,
+    // don't call it again.
+    if (!this._flushPending) {
+      this._flushPending = true;
+      this.flushCallback(() => this._flush());
+    }
+  }
+
+  _flush() {
+    // If no new definitions were defined, don't attempt to flush. This could
+    // happen if a flush callback keeps the function it is given and calls it
+    // multiple times.
+    if (this._flushPending === false) return;
+    this._flushPending = false;
+
+    const pendingDefinitions = this._pendingDefinitions;
+
+    /**
+     * Unupgraded elements with definitions that were defined *before* the last
+     * flush, in document order.
+     * @type {!Array<!HTMLElement>}
+     */
+    const elementsWithStableDefinitions = [];
+
+    /**
+     * A map from `localName`s of definitions that were defined *after* the last
+     * flush to unupgraded elements matching that definition, in document order.
+     * @type {!Map<string, !Array<!HTMLElement>>}
+     */
+    const elementsWithPendingDefinitions = new Map();
+    for (let i = 0; i < pendingDefinitions.length; i++) {
+      elementsWithPendingDefinitions.set(pendingDefinitions[i].localName, []);
+    }
+
+    this.patchAndUpgradeTree(document, {
+      upgrade: element => {
+        // Ignore the element if it has already upgraded or failed to upgrade.
+        if (element.__CE_state !== undefined) return;
+
+        const localName = element.localName;
+
+        // If there is an applicable pending definition for the element, add the
+        // element to the list of elements to be upgraded with that definition.
+        const pendingElements = elementsWithPendingDefinitions.get(localName);
+        if (pendingElements) {
+          pendingElements.push(element);
+        // If there is *any other* applicable definition for the element, add it
+        // to the list of elements with stable definitions that need to be upgraded.
+        } else if (this.localNameToDefinition(localName) ||
+            this.localNameToLazyDefinition(localName)) {
+          elementsWithStableDefinitions.push(element);
+        }
+      },
+    });
+
+    // Upgrade elements with 'stable' definitions first.
+    for (let i = 0; i < elementsWithStableDefinitions.length; i++) {
+      this.upgradeElement(elementsWithStableDefinitions[i]);
+    }
+
+    // Upgrade elements with 'pending' definitions in the order they were defined.
+    while (pendingDefinitions.length > 0) {
+      const definition = pendingDefinitions.shift();
+      const localName = definition.localName;
+
+      // Attempt to upgrade all applicable elements.
+      const pendingUpgradableElements = elementsWithPendingDefinitions.get(definition.localName);
+      for (let i = 0; i < pendingUpgradableElements.length; i++) {
+        this.upgradeElement(pendingUpgradableElements[i]);
+      }
+
+      // Resolve any promises created by `whenDefined` for the definition.
+      const deferred = this._whenDefinedDeferred.get(localName);
+      if (deferred) {
+        deferred.resolve(undefined);
+      }
+    }
+  }
+
+  /**
+   *
+   * @param {string} localName
+   */
+  flushLazyDefinition(localName) {
+    const pendingLazyDefinition = this.localNameToLazyDefinition(localName);
+
+    // only process this pending definition the first time and not while it's pending.
+    if (!pendingLazyDefinition && pendingLazyDefinition !== PENDING_LAZY_DEFINITION) {
+      return;
+    }
+
+    // mark this definition in a pending state.
+    this.setLazyDefinition(localName, PENDING_LAZY_DEFINITION);
+
+    let constructorOrPromise;
+    try {
+      constructorOrPromise = pendingLazyDefinition.constructorGenerator();
+    } catch (e) {}
+    if (!constructorOrPromise) {
+      return;
+    }
+
+    // if it's a promise, defer processing.
+    if (typeof constructorOrPromise.then === 'function') {
+      constructorOrPromise.then((constructor) => {
+        const definition = this.setupDefinition(localName, constructor);
+        if (definition) {
+          this.setLazyDefinition(localName, undefined);
+          this.processDefinition(definition);
+        }
+      });
+    } else {
+      const definition = this.setupDefinition(localName, constructorOrPromise);
+      if (definition) {
+        this.setLazyDefinition(localName, undefined);
+        return definition;
+      }
+    }
   }
 
   /**
@@ -113,11 +282,39 @@ export default class CustomElementInternals {
   }
 
   /**
+   * @param {string} localName
+   * @return {!CustomElementLazyDefinition|undefined}
+   */
+  localNameToLazyDefinition(localName) {
+    return this._localNameToLazyDefinition.get(localName);
+  }
+
+  /**
    * @param {!Function} constructor
    * @return {!CustomElementDefinition|undefined}
    */
   constructorToDefinition(constructor) {
     return this._constructorToDefinition.get(constructor);
+  }
+
+  whenDefined(localName) {
+    const prior = this._whenDefinedDeferred.get(localName);
+    if (prior) {
+      return prior.toPromise();
+    }
+
+    const deferred = new Deferred();
+    this._whenDefinedDeferred.set(localName, deferred);
+
+    const definition = this.localNameToDefinition(localName);
+    // Resolve immediately only if the given local name has a definition *and*
+    // the full document walk to upgrade elements with that local name has
+    // already happened.
+    if (definition && !this._pendingDefinitions.some(d => d.localName === localName)) {
+      deferred.resolve(undefined);
+    }
+
+    return deferred.toPromise();
   }
 
   /**
@@ -355,7 +552,8 @@ export default class CustomElementInternals {
         if (this._hasPatches) {
           this.patchElement(element);
         }
-        if (this.localNameToDefinition(element.localName)) {
+        if (this.localNameToDefinition(element.localName) ||
+            this.localNameToLazyDefinition(element.localName)) {
           elements.push(element);
         }
       }
@@ -393,10 +591,9 @@ export default class CustomElementInternals {
       !(ownerDocument.__CE_isImportDocument && ownerDocument.__CE_hasRegistry)
     ) return;
 
-    let definition = this.localNameToDefinition(element.localName);
+    const definition = this.localNameToDefinition(element.localName) ||
+      this.flushLazyDefinition(element.localName);
     if (!definition) return;
-
-    definition = this.ensureDefinitionGenerated(definition);
 
     definition.constructionStack.push(element);
 

--- a/src/CustomElementInternals.js
+++ b/src/CustomElementInternals.js
@@ -12,7 +12,7 @@ import * as Utilities from './Utilities.js';
 import CEState from './CustomElementState.js';
 
 export default class CustomElementInternals {
-  constructor() {
+  constructor(preferPerformance) {
     /** @type {!Map<string, !CustomElementDefinition>} */
     this._localNameToDefinition = new Map();
 
@@ -27,6 +27,12 @@ export default class CustomElementInternals {
 
     /** @type {boolean} */
     this._hasPatches = false;
+
+    /** @type {boolean} */
+    this._elementDefinitionIsRunning = false;
+
+    /** @type {boolean} */
+    this.preferPerformance = preferPerformance || false;
   }
 
   /**
@@ -39,8 +45,8 @@ export default class CustomElementInternals {
   }
 
   /**
-   *
-   * @param {function} constructor
+   * @param {string} localName
+   * @param {!Function} constructor
    */
   createDefinition(localName, constructor) {
     let connectedCallback;
@@ -115,6 +121,31 @@ export default class CustomElementInternals {
   }
 
   /**
+   * @param {!Node} node
+   * @param {!function(!Element)} callback
+   * @param {!Set<!Node>=} visitedImports
+   */
+  onElements(node, callback, visitedImports) {
+    if (!this.preferPerformance) {
+      Utilities.walkDeepDescendantElements(node, callback, visitedImports);
+    } else {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const element = /** @type {!Element} */(node);
+        callback(element);
+      }
+      // most easily gets to document, element, documentFragment
+      if (node.querySelectorAll) {
+        const sd = window['ShadyDOM'];
+        const elements = (!sd || !sd['inUse']) ? node.querySelectorAll('*') :
+          sd['nativeMethods'].querySelectorAll.call(node, '*');
+        for (let i = 0; i < elements.length; i++) {
+          callback(elements[i]);
+        }
+      }
+    }
+  }
+
+  /**
    * @param {!function(!Node)} patch
    */
   addNodePatch(patch) {
@@ -136,7 +167,7 @@ export default class CustomElementInternals {
   patchTree(node) {
     if (!this._hasPatches) return;
 
-    Utilities.walkDeepDescendantElements(node, element => this.patchElement(element));
+    this.onElements(node, element => this.patchElement(element));
   }
 
   /**
@@ -177,7 +208,11 @@ export default class CustomElementInternals {
   connectTree(root) {
     const elements = [];
 
-    Utilities.walkDeepDescendantElements(root, element => elements.push(element));
+    this.onElements(root, element => {
+      if (this.localNameToDefinition(element.localName)) {
+        elements.push(element);
+      }
+    });
 
     for (let i = 0; i < elements.length; i++) {
       const element = elements[i];
@@ -195,7 +230,11 @@ export default class CustomElementInternals {
   disconnectTree(root) {
     const elements = [];
 
-    Utilities.walkDeepDescendantElements(root, element => elements.push(element));
+    this.onElements(root, element => {
+      if (this.localNameToDefinition(element.localName)) {
+        elements.push(element);
+      }
+    });
 
     for (let i = 0; i < elements.length; i++) {
       const element = elements[i];
@@ -278,7 +317,8 @@ export default class CustomElementInternals {
     const elements = [];
 
     const gatherElements = element => {
-      if (element.localName === 'link' && element.getAttribute('rel') === 'import') {
+      if (!this.preferPerformance && element.localName === 'link' &&
+          element.getAttribute('rel') === 'import') {
         // The HTML Imports polyfill sets a descendant element of the link to
         // the `import` property, specifically this is *not* a Document.
         const importNode = /** @type {?Node} */ (element.import);
@@ -312,19 +352,18 @@ export default class CustomElementInternals {
           });
         }
       } else {
-        elements.push(element);
+        if (this._hasPatches) {
+          this.patchElement(element);
+        }
+        if (this.localNameToDefinition(element.localName)) {
+          elements.push(element);
+        }
       }
     };
 
-    // `walkDeepDescendantElements` populates (and internally checks against)
+    // `onElements` populates (and internally checks against)
     // `visitedImports` when traversing a loaded import.
-    Utilities.walkDeepDescendantElements(root, gatherElements, visitedImports);
-
-    if (this._hasPatches) {
-      for (let i = 0; i < elements.length; i++) {
-        this.patchElement(elements[i]);
-      }
-    }
+    this.onElements(root, gatherElements, visitedImports);
 
     for (let i = 0; i < elements.length; i++) {
       upgrade(elements[i]);

--- a/src/CustomElementRegistry.js
+++ b/src/CustomElementRegistry.js
@@ -10,7 +10,6 @@
 
 import CustomElementInternals from './CustomElementInternals.js';
 import DocumentConstructionObserver from './DocumentConstructionObserver.js';
-import Deferred from './Deferred.js';
 import * as Utilities from './Utilities.js';
 
 /**
@@ -22,42 +21,12 @@ export default class CustomElementRegistry {
    * @param {!CustomElementInternals} internals
    */
   constructor(internals) {
-    /**
-     * @private
-     * @type {boolean}
-     */
-    this._elementDefinitionIsRunning = false;
 
     /**
      * @private
      * @type {!CustomElementInternals}
      */
     this._internals = internals;
-
-    /**
-     * @private
-     * @type {!Map<string, !Deferred<undefined>>}
-     */
-    this._whenDefinedDeferred = new Map();
-
-    /**
-     * The default flush callback triggers the document walk synchronously.
-     * @private
-     * @type {!Function}
-     */
-    this._flushCallback = fn => fn();
-
-    /**
-     * @private
-     * @type {boolean}
-     */
-    this._flushPending = false;
-
-    /**
-     * @private
-     * @type {!Array<!CustomElementDefinition>}
-     */
-    this._pendingDefinitions = [];
 
     if (!internals.preferPerformance) {
       /**
@@ -68,12 +37,7 @@ export default class CustomElementRegistry {
     }
   }
 
-  /**
-   * @param {string} localName
-   * @param {!Function} constructor
-   * @param {boolean} isClassGenerator
-   */
-  _define(localName, constructor, isClassGenerator) {
+  _validateDefinition(localName, constructor) {
     if (!(constructor instanceof Function)) {
       throw new TypeError('Custom element constructors must be functions.');
     }
@@ -82,39 +46,31 @@ export default class CustomElementRegistry {
       throw new SyntaxError(`The element name '${localName}' is not valid.`);
     }
 
-    if (this._internals.localNameToDefinition(localName)) {
+    if (this._internals.localNameToDefinition(localName) ||
+        this._internals.localNameToLazyDefinition(localName)) {
       throw new Error(`A custom element with name '${localName}' has already been defined.`);
     }
 
-    if (this._elementDefinitionIsRunning) {
+    if (this._internals.elementDefinitionIsRunning) {
       throw new Error('A custom element is already being defined.');
     }
+    return true;
+  }
 
-    this._elementDefinitionIsRunning = true;
-
-    // decorate class generator
-    if (isClassGenerator) {
-      constructor.localName = localName;
-      constructor.isClassGenerator = true;
-    }
-
-    const definition = isClassGenerator ? constructor :
-      this._internals.createDefinition(localName, constructor);
-    this._elementDefinitionIsRunning = false;
-
-    // no definition or error when creating it.
-    if (!definition) {
+  /**
+   * @param {string} localName
+   * @param {!Function} constructorOrGenerator
+   * @param {boolean} isGenerator
+   */
+  _define(localName, constructorOrGenerator, isGenerator = false) {
+    if (!this._validateDefinition(localName, constructorOrGenerator)) {
       return;
     }
-
-    this._internals.setDefinition(localName, definition);
-    this._pendingDefinitions.push(definition);
-
-    // If we've already called the flush callback and it hasn't called back yet,
-    // don't call it again.
-    if (!this._flushPending) {
-      this._flushPending = true;
-      this._flushCallback(() => this._flush());
+    const definition = isGenerator ?
+      this._internals.setupLazyDefinition(localName, constructorOrGenerator) :
+      this._internals.setupDefinition(localName, constructorOrGenerator);
+    if (definition) {
+      this._internals.processDefinition(definition);
     }
   }
 
@@ -123,89 +79,19 @@ export default class CustomElementRegistry {
    * @param {!Function} constructor
    */
   define(localName, constructor) {
-    this._define(localName, constructor, false);
+    this._define(localName, constructor);
   }
 
   /**
    * @param {string} localName
    * @param {!Function} classGenerator
    */
-  lazyDefine(localName, classGenerator) {
+  polyfillDefineLazy(localName, classGenerator) {
     this._define(localName, classGenerator, true);
   }
 
   upgrade(element) {
     this._internals.patchAndUpgradeTree(element);
-  }
-
-  _flush() {
-    // If no new definitions were defined, don't attempt to flush. This could
-    // happen if a flush callback keeps the function it is given and calls it
-    // multiple times.
-    if (this._flushPending === false) return;
-    this._flushPending = false;
-
-    const pendingDefinitions = this._pendingDefinitions;
-
-    /**
-     * Unupgraded elements with definitions that were defined *before* the last
-     * flush, in document order.
-     * @type {!Array<!HTMLElement>}
-     */
-    const elementsWithStableDefinitions = [];
-
-    /**
-     * A map from `localName`s of definitions that were defined *after* the last
-     * flush to unupgraded elements matching that definition, in document order.
-     * @type {!Map<string, !Array<!HTMLElement>>}
-     */
-    const elementsWithPendingDefinitions = new Map();
-    for (let i = 0; i < pendingDefinitions.length; i++) {
-      elementsWithPendingDefinitions.set(pendingDefinitions[i].localName, []);
-    }
-
-    this._internals.patchAndUpgradeTree(document, {
-      upgrade: element => {
-        // Ignore the element if it has already upgraded or failed to upgrade.
-        if (element.__CE_state !== undefined) return;
-
-        const localName = element.localName;
-
-        // If there is an applicable pending definition for the element, add the
-        // element to the list of elements to be upgraded with that definition.
-        const pendingElements = elementsWithPendingDefinitions.get(localName);
-        if (pendingElements) {
-          pendingElements.push(element);
-        // If there is *any other* applicable definition for the element, add it
-        // to the list of elements with stable definitions that need to be upgraded.
-        } else if (this._internals.localNameToDefinition(localName)) {
-          elementsWithStableDefinitions.push(element);
-        }
-      },
-    });
-
-    // Upgrade elements with 'stable' definitions first.
-    for (let i = 0; i < elementsWithStableDefinitions.length; i++) {
-      this._internals.upgradeElement(elementsWithStableDefinitions[i]);
-    }
-
-    // Upgrade elements with 'pending' definitions in the order they were defined.
-    while (pendingDefinitions.length > 0) {
-      const definition = pendingDefinitions.shift();
-      const localName = definition.localName;
-
-      // Attempt to upgrade all applicable elements.
-      const pendingUpgradableElements = elementsWithPendingDefinitions.get(definition.localName);
-      for (let i = 0; i < pendingUpgradableElements.length; i++) {
-        this._internals.upgradeElement(pendingUpgradableElements[i]);
-      }
-
-      // Resolve any promises created by `whenDefined` for the definition.
-      const deferred = this._whenDefinedDeferred.get(localName);
-      if (deferred) {
-        deferred.resolve(undefined);
-      }
-    }
   }
 
   /**
@@ -215,7 +101,6 @@ export default class CustomElementRegistry {
   get(localName) {
     let definition = this._internals.localNameToDefinition(localName);
     if (definition) {
-      definition = this._internals.ensureDefinitionGenerated(definition);
       return definition.constructorFunction;
     }
 
@@ -230,39 +115,22 @@ export default class CustomElementRegistry {
     if (!Utilities.isValidCustomElementName(localName)) {
       return Promise.reject(new SyntaxError(`'${localName}' is not a valid custom element name.`));
     }
-
-    const prior = this._whenDefinedDeferred.get(localName);
-    if (prior) {
-      return prior.toPromise();
-    }
-
-    const deferred = new Deferred();
-    this._whenDefinedDeferred.set(localName, deferred);
-
-    const definition = this._internals.localNameToDefinition(localName);
-    // Resolve immediately only if the given local name has a definition *and*
-    // the full document walk to upgrade elements with that local name has
-    // already happened.
-    if (definition && !this._pendingDefinitions.some(d => d.localName === localName)) {
-      deferred.resolve(undefined);
-    }
-
-    return deferred.toPromise();
+    return this._internals.whenDefined(localName);
   }
 
   polyfillWrapFlushCallback(outer) {
     if (this._documentConstructionObserver) {
       this._documentConstructionObserver.disconnect();
     }
-    const inner = this._flushCallback;
-    this._flushCallback = flush => outer(() => inner(flush));
+    const inner = this._internals.flushCallback;
+    this._internals.flushCallback = flush => outer(() => inner(flush));
   }
 }
 
 // Closure compiler exports.
 window['CustomElementRegistry'] = CustomElementRegistry;
 CustomElementRegistry.prototype['define'] = CustomElementRegistry.prototype.define;
-CustomElementRegistry.prototype['lazyDefine'] = CustomElementRegistry.prototype.lazyDefine;
+CustomElementRegistry.prototype['polyfillDefineLazy'] = CustomElementRegistry.prototype.polyfillDefineLazy;
 CustomElementRegistry.prototype['upgrade'] = CustomElementRegistry.prototype.upgrade;
 CustomElementRegistry.prototype['get'] = CustomElementRegistry.prototype.get;
 CustomElementRegistry.prototype['whenDefined'] = CustomElementRegistry.prototype.whenDefined;

--- a/src/CustomElementRegistry.js
+++ b/src/CustomElementRegistry.js
@@ -66,6 +66,11 @@ export default class CustomElementRegistry {
     this._documentConstructionObserver = new DocumentConstructionObserver(internals, document);
   }
 
+  /**
+   * @param {string} localName
+   * @param {!Function} constructor
+   * @param {boolean} isClassGenerator
+   */
   _define(localName, constructor, isClassGenerator) {
     if (!(constructor instanceof Function)) {
       throw new TypeError('Custom element constructors must be functions.');
@@ -94,6 +99,11 @@ export default class CustomElementRegistry {
     const definition = isClassGenerator ? constructor :
       this._internals.createDefinition(localName, constructor);
     this._elementDefinitionIsRunning = false;
+
+    // no definition or error when creating it.
+    if (!definition) {
+      return;
+    }
 
     this._internals.setDefinition(localName, definition);
     this._pendingDefinitions.push(definition);
@@ -201,9 +211,9 @@ export default class CustomElementRegistry {
    * @return {Function|undefined}
    */
   get(localName) {
-    const definition = this._internals.localNameToDefinition(localName);
+    let definition = this._internals.localNameToDefinition(localName);
     if (definition) {
-      this._internals.ensureDefinitionGenerated(definition);
+      definition = this._internals.ensureDefinitionGenerated(definition);
       return definition.constructorFunction;
     }
 
@@ -248,6 +258,7 @@ export default class CustomElementRegistry {
 // Closure compiler exports.
 window['CustomElementRegistry'] = CustomElementRegistry;
 CustomElementRegistry.prototype['define'] = CustomElementRegistry.prototype.define;
+CustomElementRegistry.prototype['lazyDefine'] = CustomElementRegistry.prototype.lazyDefine;
 CustomElementRegistry.prototype['upgrade'] = CustomElementRegistry.prototype.upgrade;
 CustomElementRegistry.prototype['get'] = CustomElementRegistry.prototype.get;
 CustomElementRegistry.prototype['whenDefined'] = CustomElementRegistry.prototype.whenDefined;

--- a/src/CustomElementRegistry.js
+++ b/src/CustomElementRegistry.js
@@ -59,11 +59,13 @@ export default class CustomElementRegistry {
      */
     this._pendingDefinitions = [];
 
-    /**
-     * @private
-     * @type {!DocumentConstructionObserver}
-     */
-    this._documentConstructionObserver = new DocumentConstructionObserver(internals, document);
+    if (!internals.preferPerformance) {
+      /**
+      * @private
+      * @type {!DocumentConstructionObserver}
+      */
+      this._documentConstructionObserver = new DocumentConstructionObserver(internals, document);
+    }
   }
 
   /**
@@ -249,7 +251,9 @@ export default class CustomElementRegistry {
   }
 
   polyfillWrapFlushCallback(outer) {
-    this._documentConstructionObserver.disconnect();
+    if (this._documentConstructionObserver) {
+      this._documentConstructionObserver.disconnect();
+    }
     const inner = this._flushCallback;
     this._flushCallback = flush => outer(() => inner(flush));
   }

--- a/src/Patch/Document.js
+++ b/src/Patch/Document.js
@@ -27,9 +27,9 @@ export default function(internals) {
     function(localName) {
       // Only create custom elements if this document is associated with the registry.
       if (this.__CE_hasRegistry) {
-        let definition = internals.localNameToDefinition(localName);
+        const definition = internals.localNameToDefinition(localName) ||
+          internals.flushLazyDefinition(localName);
         if (definition) {
-          definition = internals.ensureDefinitionGenerated(definition);
           return new (definition.constructorFunction)();
         }
       }
@@ -70,9 +70,9 @@ export default function(internals) {
     function(namespace, localName) {
       // Only create custom elements if this document is associated with the registry.
       if (this.__CE_hasRegistry && (namespace === null || namespace === NS_HTML)) {
-        let definition = internals.localNameToDefinition(localName);
+        let definition = internals.localNameToDefinition(localName)  ||
+          internals.flushLazyDefinition(localName);
         if (definition) {
-          definition = internals.ensureDefinitionGenerated(definition);
           return new (definition.constructorFunction)();
         }
       }

--- a/src/Patch/Document.js
+++ b/src/Patch/Document.js
@@ -27,8 +27,9 @@ export default function(internals) {
     function(localName) {
       // Only create custom elements if this document is associated with the registry.
       if (this.__CE_hasRegistry) {
-        const definition = internals.localNameToDefinition(localName);
+        let definition = internals.localNameToDefinition(localName);
         if (definition) {
+          definition = internals.ensureDefinitionGenerated(definition);
           return new (definition.constructorFunction)();
         }
       }
@@ -69,8 +70,9 @@ export default function(internals) {
     function(namespace, localName) {
       // Only create custom elements if this document is associated with the registry.
       if (this.__CE_hasRegistry && (namespace === null || namespace === NS_HTML)) {
-        const definition = internals.localNameToDefinition(localName);
+        let definition = internals.localNameToDefinition(localName);
         if (definition) {
+          definition = internals.ensureDefinitionGenerated(definition);
           return new (definition.constructorFunction)();
         }
       }

--- a/src/Patch/Element.js
+++ b/src/Patch/Element.js
@@ -53,8 +53,9 @@ export default function(internals) {
         let removedElements = undefined;
         if (isConnected) {
           removedElements = [];
-          Utilities.walkDeepDescendantElements(this, element => {
-            if (element !== this) {
+          internals.onElements(this, element => {
+            if (element !== this &&
+                internals.localNameToDefinition(element.localName)) {
               removedElements.push(element);
             }
           });

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -35,6 +35,13 @@ const nativeContains = document.contains ? document.contains.bind(document) :
 
 /**
  * @param {!Node} node
+ */
+export function isElementOrShadowRoot(node) {
+  return (node instanceof Element || node instanceof ShadowRoot);
+}
+
+/**
+ * @param {!Node} node
  * @return {boolean}
  */
 export function isConnected(node) {
@@ -54,6 +61,23 @@ export function isConnected(node) {
     current = current.parentNode || (window.ShadowRoot && current instanceof ShadowRoot ? current.host : undefined);
   }
   return !!(current && (current.__CE_isImportDocument || current instanceof Document));
+}
+
+/**
+ * @param {!DocumentFragment} fragment
+ * @return {Array<!Element>}
+ */
+export function childrenFromFragment(fragment) {
+  if (fragment.children) {
+    return Array.prototype.slice.call(fragment.children);
+  }
+  const children = [];
+  for (let n = fragment.firstChild; n; n = n.nextSibling) {
+    if (n.nodeType === Node.ELEMENT_NODE) {
+      children.push(n);
+    }
+  }
+  return children;
 }
 
 /**

--- a/src/custom-elements.js
+++ b/src/custom-elements.js
@@ -23,8 +23,11 @@ if (!priorCustomElements ||
      priorCustomElements['forcePolyfill'] ||
      (typeof priorCustomElements['define'] != 'function') ||
      (typeof priorCustomElements['get'] != 'function')) {
+
+  const preferPerformance = priorCustomElements && priorCustomElements['preferPerformance'];
+
   /** @type {!CustomElementInternals} */
-  const internals = new CustomElementInternals();
+  const internals = new CustomElementInternals(preferPerformance);
 
   PatchHTMLElement(internals);
   PatchDocument(internals);

--- a/tests/index.html
+++ b/tests/index.html
@@ -27,6 +27,7 @@
     'js/closure.js',
     'js/upgrade.js',
     'js/shadow-dom.js',
+    'js/polyfill-lazy-define.js',
     'html/registry-upgrade.html',
     'html/polyfillWrapFlushCallback/index.html',
     'html/imports.html',

--- a/tests/js/polyfill-lazy-define.js
+++ b/tests/js/polyfill-lazy-define.js
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+suite('polyfillLazyDefine', function() {
+  var work;
+  var assert = chai.assert;
+  var HTMLNS = 'http://www.w3.org/1999/xhtml';
+
+  customElements.enableFlush = true;
+
+  setup(function() {
+    work = document.createElement('div');
+    document.body.appendChild(work);
+  });
+
+  teardown(function() {
+    document.body.removeChild(work);
+  });
+
+  suite('defining', function() {
+
+    test('requires a name argument', function() {
+      assert.throws(function() {
+        customElements.polyfillDefineLazy();
+      }, '', 'customElements.define failed to throw when given no arguments');
+    });
+
+    test('name must contain a dash', function() {
+      assert.throws(function () {
+        customElements.polyfillDefineLazy('xfoo', () => {prototype: Object.create(HTMLElement.prototype)});
+      }, '', 'customElements.define failed to throw when given no arguments');
+    });
+
+    test('name must not be a reserved name', function() {
+      assert.throws(function() {
+        customElements.polyfillDefineLazy('font-face', () => {prototype: Object.create(HTMLElement.prototype)});
+      }, '', 'Failed to execute \'defineElement\' on \'Document\': Registration failed for type \'font-face\'. The type name is invalid.');
+    });
+
+    test('name must be unique', function() {
+      const generator = () => class XDuplicate extends HTMLElement {};
+      customElements.polyfillDefineLazy('x-lazy-duplicate', generator);
+      assert.throws(function() {
+        customElements.polyfillDefineLazy('x-lazy-duplicate', generator);
+      }, '', 'customElements.define failed to throw when called multiple times with the same element name');
+    });
+
+    test('name must be unique and not defined', function() {
+      customElements.define('x-lazy-duplicate-define', class extends HTMLElement {});
+      assert.throws(function() {
+        customElements.polyfillDefineLazy('x-lazy-duplicate-define', () => class extends HTMLElement {});
+      }, '', 'customElements.define failed to throw when called multiple times with the same element name');
+    });
+
+    test('names are case-sensitive', function() {
+      const generator = () => class XCase extends HTMLElement {};
+      assert.throws(function() { customElements.polyfillDefineLazy('X-CASE', generator); });
+    });
+
+    test('requires a constructor argument', function() {
+      assert.throws(function () {
+        customElements.polyfillDefineLazy('x-no-options');
+      }, '', 'customElements.define failed to throw without a constructor argument');
+    });
+
+  });
+
+  suite('get', function() {
+
+    test('returns undefined and constructor after element upgrades', function() {
+      customElements.polyfillDefineLazy('x-get-lazy', () => class extends HTMLElement {});
+      assert.isUndefined(customElements.get('x-get-lazy'));
+      document.createElement('x-get-lazy');
+      assert.ok(customElements.get('x-get-lazy'));
+    });
+
+  });
+
+  suite('whenDefined', function() {
+
+    test('resolves when a lazy define is first upgraded', function() {
+      customElements.polyfillDefineLazy('x-when-defined-lazy', () =>class extends HTMLElement {});
+      const el = document.createElement('x-when-defined-lazy');
+      work.appendChild(el);
+      return customElements.whenDefined('x-when-defined-lazy');
+    });
+
+    test('resolves when a lazy define promise is first upgraded', function() {
+      customElements.polyfillDefineLazy('x-when-defined-lazy-promise', () =>
+        new Promise((resolve) => resolve(class extends HTMLElement {})));
+      const el = document.createElement('x-when-defined-lazy-promise');
+      work.appendChild(el);
+      return customElements.whenDefined('x-when-defined-lazy-promise');
+    });
+
+  });
+
+  suite('upgrades', function() {
+
+    test('createElement upgrades when defined (without promise)', function() {
+      customElements.polyfillDefineLazy('lazy-create-upgrade', () => {
+        return class extends HTMLElement {
+          constructor() {
+            super();
+            this.upgraded = true;
+          }
+        }
+      });
+      const el = document.createElement('lazy-create-upgrade');
+      assert.isTrue(el.upgraded);
+    });
+
+    test('createElement/connect upgrades when defined (with promise)', function(done) {
+      customElements.polyfillDefineLazy('lazy-promise-create-upgrade', () =>
+        new Promise((resolve) => resolve(class extends HTMLElement {
+          constructor() {
+            super();
+            this.upgraded = true;
+          }
+          connectedCallback() {
+            this.connected = true;
+          }
+        })));
+      const el = document.createElement('lazy-promise-create-upgrade');
+      work.appendChild(el);
+      customElements.whenDefined('lazy-promise-create-upgrade').then(() => {
+        assert.isTrue(el.upgraded);
+        assert.isTrue(el.connected);
+        done();
+      });
+
+    });
+
+    test('element in dom upgrades (without promise)', function() {
+      const el = document.createElement('lazy-dom-upgrade');
+      work.appendChild(el);
+      customElements.polyfillDefineLazy('lazy-dom-upgrade', () => {
+        return class extends HTMLElement {
+          constructor() {
+            super();
+            this.upgraded = true;
+          }
+          connectedCallback() {
+            this.connected = true;
+          }
+        }
+      });
+      assert.isTrue(el.upgraded);
+      assert.isTrue(el.connected);
+    });
+
+    test('element in dom upgrades (with promise)', function(done) {
+      const el = document.createElement('lazy-promise-dom-upgrade');
+      work.appendChild(el);
+      customElements.polyfillDefineLazy('lazy-promise-dom-upgrade', () =>
+        new Promise((resolve) => resolve(class extends HTMLElement {
+          constructor() {
+            super();
+            this.upgraded = true;
+          }
+          connectedCallback() {
+            this.connected = true;
+          }
+        })));
+      customElements.whenDefined('lazy-promise-dom-upgrade').then(() => {
+        assert.isTrue(el.upgraded);
+        assert.isTrue(el.connected);
+        done();
+      });
+    });
+
+   });
+
+});


### PR DESCRIPTION
Fixes #200 by adding `customElements.polyfillDefineLazy(name, constructorGenerator)` and adds a `preferPerformance` option. 

The `customElements.polyfillDefineLazy` is an approximation of a potential spec feature to allow definitions to be processed lazily when the first element to customize is found. The `constructorGenerator` is a function that's invoked only the first time and element to customize is found. It can return an element constructor function or a promise that resolves to an element constructor function.

Setting `customElements.preferPerformance` (1) will use `querySelectorAll` to find elements to upgrade, connect, and disconnect, (2) does not use the document construction observer to upgrade the document. This setting improves performance but reduces correctness in some cases: (1) removes support for upgrading custom elements inside HTMLImports, (2) does not upgrade undistributed custom elements in polyfilled shadow roots, and (3) elements do not upgrade with Mutation Observer timing, which is less spec correct.