### PR TITLE
Adds a number of small optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,12 +236,12 @@ These settings typically have correctness trade offs (noted below) and should be
 used with caution.
 
 * `customElements.noDocumentConstructionObserver`: Set this flag to true to
-prevent the polyfill from mutation observing and upgrading DOM as it is added.
-This provides a small performance improvement during document parsing.
-With this setting on, the polyfill will not upgrade parser generated elements
-defined after an element definition. This setting should be used in
-conjunction with a `polyfillWrapFlushCallback` that defers element upgrades
-until the parser is complete.
+prevent the polyfill from mutation observing and upgrading DOM as it is added
+to the main document. This provides a small performance improvement during
+document parsing. With this setting on, the polyfill will not upgrade elements
+created when parsing the main document's HTML. This setting should be
+used in conjunction with a `polyfillWrapFlushCallback` that defers element
+upgrades until the parser is complete.
 
 * `customElements.shadyDomFastWalk`: Set this flag to true when using the
 ShadyDOM polyfill to optimize how elements are found in the DOM. There are a

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ customElements.define('c-e', class extends HTMLElement {});
 // The document is walked to attempt upgrades.
 ```
 
-## Settings
+### Settings
 
 The polyfill provides a few settings to improve performance by tweaking behavior.
 These settings typically have correctness trade offs (noted below) and should be

--- a/README.md
+++ b/README.md
@@ -228,3 +228,23 @@ customElements.define('c-e', class extends HTMLElement {});
 // 'added first'
 // The document is walked to attempt upgrades.
 ```
+
+## Settings
+
+The polyfill provides a few settings to improve performance by tweaking behavior.
+These settings typically have correctness trade offs (noted below) and should be
+used with caution.
+
+* `customElements.noDocumentConstructionObserver`: Set this flag to true to
+prevent the polyfill from mutation observing and upgrading DOM as it is added.
+This provides a small performance improvement during document parsing.
+With this setting on, the polyfill will not upgrade parser generated elements
+defined after an element definition. This setting should be used in
+conjunction with a `polyfillWrapFlushCallback` that defers element upgrades
+until the parser is complete.
+
+* `customElements.shadyDomFastWalk`: Set this flag to true when using the
+ShadyDOM polyfill to optimize how elements are found in the DOM. There are a
+couple of limitations: (1) Elements that are children of Shadow DOM hosts and
+are not distributed to slots may not upgrade; (2) This setting is not compatible
+with using native HTML Imports.

--- a/externs/custom-elements.js
+++ b/externs/custom-elements.js
@@ -12,6 +12,9 @@
 /** @type {boolean|undefined} */
 CustomElementRegistry.prototype.forcePolyfill;
 
+/** @type {boolean|undefined} */
+CustomElementRegistry.prototype.preferPerformance;
+
 class AlreadyConstructedMarkerType {}
 
 /**

--- a/externs/custom-elements.js
+++ b/externs/custom-elements.js
@@ -13,9 +13,6 @@
 CustomElementRegistry.prototype.forcePolyfill;
 
 /** @type {boolean|undefined} */
-CustomElementRegistry.prototype.noHtmlImports;
-
-/** @type {boolean|undefined} */
 CustomElementRegistry.prototype.noConstructionObserver;
 
 /** @type {boolean|undefined} */

--- a/externs/custom-elements.js
+++ b/externs/custom-elements.js
@@ -13,10 +13,10 @@
 CustomElementRegistry.prototype.forcePolyfill;
 
 /** @type {boolean|undefined} */
-CustomElementRegistry.prototype.noConstructionObserver;
+CustomElementRegistry.prototype.noDocumentConstructionObserver;
 
 /** @type {boolean|undefined} */
-CustomElementRegistry.prototype.fastWalk;
+CustomElementRegistry.prototype.shadyDomFastWalk;
 
 class AlreadyConstructedMarkerType {}
 

--- a/externs/custom-elements.js
+++ b/externs/custom-elements.js
@@ -13,7 +13,13 @@
 CustomElementRegistry.prototype.forcePolyfill;
 
 /** @type {boolean|undefined} */
-CustomElementRegistry.prototype.preferPerformance;
+CustomElementRegistry.prototype.noHtmlImports;
+
+/** @type {boolean|undefined} */
+CustomElementRegistry.prototype.noConstructionObserver;
+
+/** @type {boolean|undefined} */
+CustomElementRegistry.prototype.fastWalk;
 
 class AlreadyConstructedMarkerType {}
 

--- a/src/CustomElementInternals.js
+++ b/src/CustomElementInternals.js
@@ -32,9 +32,11 @@ export default class CustomElementInternals {
     /** @type {boolean} */
     this._hasPatches = false;
 
-    /** @type {boolean} */
-    this.fastWalk = options.fastWalk;
-    this.useConstructionObserver = !options.noConstructionObserver;
+    /** @const {boolean} */
+    this.shadyDomFastWalk = options.shadyDomFastWalk;
+
+    /** @const {boolean} */
+    this.useDocumentConstructionObserver = !options.noDocumentConstructionObserver;
   }
 
   /**
@@ -69,7 +71,7 @@ export default class CustomElementInternals {
    */
   forEachElement(node, callback, visitedImports) {
     const sd = window['ShadyDOM'];
-    if (this.fastWalk && sd && sd['inUse']) {
+    if (this.shadyDomFastWalk && sd && sd['inUse']) {
       if (node.nodeType === Node.ELEMENT_NODE) {
         const element = /** @type {!Element} */(node);
         callback(element);

--- a/src/CustomElementInternals.js
+++ b/src/CustomElementInternals.js
@@ -83,7 +83,6 @@ export default class CustomElementInternals {
         }
       }
     } else {
-      console.log('slow walk');
       Utilities.walkDeepDescendantElements(node, callback, visitedImports);
     }
   }

--- a/src/CustomElementInternals.js
+++ b/src/CustomElementInternals.js
@@ -34,7 +34,6 @@ export default class CustomElementInternals {
 
     /** @type {boolean} */
     this.fastWalk = options.fastWalk;
-    this.supportHtmlImports = !options.noHtmlImports;
     this.useConstructionObserver = !options.noConstructionObserver;
   }
 
@@ -254,7 +253,7 @@ export default class CustomElementInternals {
       if (this._hasPatches) {
         this.patchElement(element);
       }
-      if (this.supportHtmlImports && element.localName === 'link' &&
+      if (element.localName === 'link' &&
           element.getAttribute('rel') === 'import') {
         // The HTML Imports polyfill sets a descendant element of the link to
         // the `import` property, specifically this is *not* a Document.

--- a/src/CustomElementInternals.js
+++ b/src/CustomElementInternals.js
@@ -14,7 +14,10 @@ import CEState from './CustomElementState.js';
 export default class CustomElementInternals {
 
   /**
-   * @param {!Object} options
+   * @param {{
+   *   shadyDomFastWalk: boolean,
+   *   useDocumentConstructionObserver: boolean,
+   * }} options
    */
   constructor(options) {
     /** @type {!Map<string, !CustomElementDefinition>} */

--- a/src/CustomElementRegistry.js
+++ b/src/CustomElementRegistry.js
@@ -61,7 +61,7 @@ export default class CustomElementRegistry {
 
     /**
     * @private
-    * @type {!DocumentConstructionObserver|undefined}
+    * @const {!DocumentConstructionObserver|undefined}
     */
     this._documentConstructionObserver = internals.useDocumentConstructionObserver ?
       new DocumentConstructionObserver(internals, document) : undefined;

--- a/src/CustomElementRegistry.js
+++ b/src/CustomElementRegistry.js
@@ -60,10 +60,11 @@ export default class CustomElementRegistry {
     this._pendingDefinitions = [];
 
     /**
-     * @private
-     * @type {!DocumentConstructionObserver}
-     */
-    this._documentConstructionObserver = new DocumentConstructionObserver(internals, document);
+    * @private
+    * @type {!DocumentConstructionObserver|undefined}
+    */
+    this._documentConstructionObserver = internals.preferPerformance ?
+      undefined : new DocumentConstructionObserver(internals, document);
   }
 
   /**
@@ -257,7 +258,9 @@ export default class CustomElementRegistry {
   }
 
   polyfillWrapFlushCallback(outer) {
-    this._documentConstructionObserver.disconnect();
+    if (this._documentConstructionObserver) {
+      this._documentConstructionObserver.disconnect();
+    }
     const inner = this._flushCallback;
     this._flushCallback = flush => outer(() => inner(flush));
   }

--- a/src/CustomElementRegistry.js
+++ b/src/CustomElementRegistry.js
@@ -63,7 +63,7 @@ export default class CustomElementRegistry {
     * @private
     * @type {!DocumentConstructionObserver|undefined}
     */
-    this._documentConstructionObserver = internals.useConstructionObserver ?
+    this._documentConstructionObserver = internals.useDocumentConstructionObserver ?
       new DocumentConstructionObserver(internals, document) : undefined;
   }
 

--- a/src/CustomElementRegistry.js
+++ b/src/CustomElementRegistry.js
@@ -63,8 +63,8 @@ export default class CustomElementRegistry {
     * @private
     * @type {!DocumentConstructionObserver|undefined}
     */
-    this._documentConstructionObserver = internals.preferPerformance ?
-      undefined : new DocumentConstructionObserver(internals, document);
+    this._documentConstructionObserver = internals.useConstructionObserver ?
+      new DocumentConstructionObserver(internals, document) : undefined;
   }
 
   /**

--- a/src/Patch/Element.js
+++ b/src/Patch/Element.js
@@ -54,8 +54,7 @@ export default function(internals) {
         if (isConnected) {
           removedElements = [];
           internals.forEachElement(this, element => {
-            if (element !== this &&
-                internals.localNameToDefinition(element.localName)) {
+            if (element !== this) {
               removedElements.push(element);
             }
           });

--- a/src/Patch/Element.js
+++ b/src/Patch/Element.js
@@ -53,8 +53,9 @@ export default function(internals) {
         let removedElements = undefined;
         if (isConnected) {
           removedElements = [];
-          Utilities.walkDeepDescendantElements(this, element => {
-            if (element !== this) {
+          internals.forEachElement(this, element => {
+            if (element !== this &&
+                internals.localNameToDefinition(element.localName)) {
               removedElements.push(element);
             }
           });

--- a/src/Patch/Node.js
+++ b/src/Patch/Node.js
@@ -154,7 +154,7 @@ export default function(internals) {
         return nativeResult;
       }
 
-      const nodeToInsertWasConnected = nodeToInsert instanceof Element &&
+      const nodeToInsertWasConnectedElement = nodeToInsert instanceof Element &&
         Utilities.isConnected(nodeToInsert);
       const nativeResult = Native.Node_replaceChild.call(this, nodeToInsert, nodeToRemove);
       const thisIsConnected = Utilities.isConnected(this);
@@ -163,7 +163,7 @@ export default function(internals) {
         internals.disconnectTree(nodeToRemove);
       }
 
-      if (nodeToInsertWasConnected) {
+      if (nodeToInsertWasConnectedElement) {
         internals.disconnectTree(nodeToInsert);
       }
 

--- a/src/Patch/Node.js
+++ b/src/Patch/Node.js
@@ -27,7 +27,6 @@ export default function(internals) {
      * @return {!Node}
      */
     function(node, refNode) {
-      const needsConnectTree = Utilities.isConnected(this);
       if (node instanceof DocumentFragment) {
         const insertedNodes = Utilities.childrenFromFragment(node);
         const nativeResult = Native.Node_insertBefore.call(this, node, refNode);
@@ -35,7 +34,7 @@ export default function(internals) {
         // DocumentFragments can't be connected, so `disconnectTree` will never
         // need to be called on a DocumentFragment's children after inserting it.
 
-        if (needsConnectTree) {
+        if (Utilities.isConnected(this)) {
           for (let i = 0; i < insertedNodes.length; i++) {
             internals.connectTree(insertedNodes[i]);
           }
@@ -51,7 +50,7 @@ export default function(internals) {
         internals.disconnectTree(node);
       }
 
-      if (needsConnectTree) {
+      if (Utilities.isConnected(this)) {
         internals.connectTree(node);
       }
 
@@ -65,7 +64,6 @@ export default function(internals) {
      * @return {!Node}
      */
     function(node) {
-      const needsConnectTree = Utilities.isConnected(this);
       if (node instanceof DocumentFragment) {
         const insertedNodes = Utilities.childrenFromFragment(node);
         const nativeResult = Native.Node_appendChild.call(this, node);
@@ -73,7 +71,7 @@ export default function(internals) {
         // DocumentFragments can't be connected, so `disconnectTree` will never
         // need to be called on a DocumentFragment's children after inserting it.
 
-        if (needsConnectTree) {
+        if (Utilities.isConnected(this)) {
           for (let i = 0; i < insertedNodes.length; i++) {
             internals.connectTree(insertedNodes[i]);
           }
@@ -89,7 +87,7 @@ export default function(internals) {
         internals.disconnectTree(node);
       }
 
-      if (needsConnectTree) {
+      if (Utilities.isConnected(this)) {
         internals.connectTree(node);
       }
 
@@ -139,7 +137,6 @@ export default function(internals) {
      * @return {!Node}
      */
     function(nodeToInsert, nodeToRemove) {
-      const needsConnectTree = Utilities.isConnected(this);
       if (nodeToInsert instanceof DocumentFragment) {
         const insertedNodes = Utilities.childrenFromFragment(nodeToInsert);
         const nativeResult = Native.Node_replaceChild.call(this, nodeToInsert, nodeToRemove);
@@ -147,7 +144,7 @@ export default function(internals) {
         // DocumentFragments can't be connected, so `disconnectTree` will never
         // need to be called on a DocumentFragment's children after inserting it.
 
-        if (needsConnectTree) {
+        if (Utilities.isConnected(this)) {
           internals.disconnectTree(nodeToRemove);
           for (let i = 0; i < insertedNodes.length; i++) {
             internals.connectTree(insertedNodes[i]);
@@ -160,8 +157,9 @@ export default function(internals) {
       const nodeToInsertWasConnected = nodeToInsert instanceof Element &&
         Utilities.isConnected(nodeToInsert);
       const nativeResult = Native.Node_replaceChild.call(this, nodeToInsert, nodeToRemove);
+      const thisIsConnected = Utilities.isConnected(this);
 
-      if (needsConnectTree) {
+      if (thisIsConnected) {
         internals.disconnectTree(nodeToRemove);
       }
 
@@ -169,7 +167,7 @@ export default function(internals) {
         internals.disconnectTree(nodeToInsert);
       }
 
-      if (needsConnectTree) {
+      if (thisIsConnected) {
         internals.connectTree(nodeToInsert);
       }
 

--- a/src/Patch/Node.js
+++ b/src/Patch/Node.js
@@ -27,8 +27,7 @@ export default function(internals) {
      * @return {!Node}
      */
     function(node, refNode) {
-      const needsConnectTree = Utilities.isElementOrShadowRoot(this) &&
-        Utilities.isConnected(this);
+      const needsConnectTree = Utilities.isConnected(this);
       if (node instanceof DocumentFragment) {
         const insertedNodes = Utilities.childrenFromFragment(node);
         const nativeResult = Native.Node_insertBefore.call(this, node, refNode);
@@ -45,10 +44,10 @@ export default function(internals) {
         return nativeResult;
       }
 
-      const nodeWasConnected = node instanceof Element && Utilities.isConnected(node);
+      const nodeWasConnectedElement = node instanceof Element && Utilities.isConnected(node);
       const nativeResult = Native.Node_insertBefore.call(this, node, refNode);
 
-      if (nodeWasConnected) {
+      if (nodeWasConnectedElement) {
         internals.disconnectTree(node);
       }
 
@@ -66,8 +65,7 @@ export default function(internals) {
      * @return {!Node}
      */
     function(node) {
-      const needsConnectTree = Utilities.isElementOrShadowRoot(this) &&
-        Utilities.isConnected(this);
+      const needsConnectTree = Utilities.isConnected(this);
       if (node instanceof DocumentFragment) {
         const insertedNodes = Utilities.childrenFromFragment(node);
         const nativeResult = Native.Node_appendChild.call(this, node);
@@ -84,10 +82,10 @@ export default function(internals) {
         return nativeResult;
       }
 
-      const nodeWasConnected = node instanceof Element && Utilities.isConnected(node);
+      const nodeWasConnectedElement = node instanceof Element && Utilities.isConnected(node);
       const nativeResult = Native.Node_appendChild.call(this, node);
 
-      if (nodeWasConnected) {
+      if (nodeWasConnectedElement) {
         internals.disconnectTree(node);
       }
 
@@ -123,10 +121,10 @@ export default function(internals) {
      * @return {!Node}
      */
     function(node) {
-      const nodeWasConnected = node instanceof Element && Utilities.isConnected(node);
+      const nodeWasConnectedElement = node instanceof Element && Utilities.isConnected(node);
       const nativeResult = Native.Node_removeChild.call(this, node);
 
-      if (nodeWasConnected) {
+      if (nodeWasConnectedElement) {
         internals.disconnectTree(node);
       }
 
@@ -141,8 +139,7 @@ export default function(internals) {
      * @return {!Node}
      */
     function(nodeToInsert, nodeToRemove) {
-      const needsConnectTree = Utilities.isElementOrShadowRoot(this) &&
-        Utilities.isConnected(this);
+      const needsConnectTree = Utilities.isConnected(this);
       if (nodeToInsert instanceof DocumentFragment) {
         const insertedNodes = Utilities.childrenFromFragment(nodeToInsert);
         const nativeResult = Native.Node_replaceChild.call(this, nodeToInsert, nodeToRemove);
@@ -200,8 +197,7 @@ export default function(internals) {
           // care about elements.
           const childNodes = this.childNodes;
           const childNodesLength = childNodes.length;
-          if (childNodesLength > 0 && Utilities.isElementOrShadowRoot(this) &&
-              Utilities.isConnected(this)) {
+          if (childNodesLength > 0 && Utilities.isConnected(this)) {
             // Copying an array by iterating is faster than using slice.
             removedNodes = new Array(childNodesLength);
             for (let i = 0; i < childNodesLength; i++) {

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -35,13 +35,6 @@ const nativeContains = document.contains ? document.contains.bind(document) :
 
 /**
  * @param {!Node} node
- */
-export function isElementOrShadowRoot(node) {
-  return (node instanceof Element || node instanceof ShadowRoot);
-}
-
-/**
- * @param {!Node} node
  * @return {boolean}
  */
 export function isConnected(node) {

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -35,6 +35,13 @@ const nativeContains = document.contains ? document.contains.bind(document) :
 
 /**
  * @param {!Node} node
+ */
+export function isElementOrShadowRoot(node) {
+  return (node instanceof Element || node instanceof ShadowRoot);
+}
+
+/**
+ * @param {!Node} node
  * @return {boolean}
  */
 export function isConnected(node) {
@@ -54,6 +61,23 @@ export function isConnected(node) {
     current = current.parentNode || (window.ShadowRoot && current instanceof ShadowRoot ? current.host : undefined);
   }
   return !!(current && (current.__CE_isImportDocument || current instanceof Document));
+}
+
+/**
+ * @param {!DocumentFragment} fragment
+ * @return {!Array<!Element>}
+ */
+export function childrenFromFragment(fragment) {
+  if (fragment.children) {
+    return Array.prototype.slice.call(fragment.children);
+  }
+  const children = [];
+  for (let n = fragment.firstChild; n; n = n.nextSibling) {
+    if (n.nodeType === Node.ELEMENT_NODE) {
+      children.push(n);
+    }
+  }
+  return children;
 }
 
 /**

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -68,6 +68,7 @@ export function isConnected(node) {
  * @return {!Array<!Element>}
  */
 export function childrenFromFragment(fragment) {
+  // Note, IE doesn't have `children` on document fragments.
   if (fragment.children) {
     return Array.prototype.slice.call(fragment.children);
   }

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -62,8 +62,9 @@ export function isConnected(node) {
  */
 export function childrenFromFragment(fragment) {
   // Note, IE doesn't have `children` on document fragments.
-  if (fragment.children) {
-    return Array.prototype.slice.call(fragment.children);
+  const nativeChildren = fragment.children;
+  if (nativeChildren) {
+    return Array.prototype.slice.call(nativeChildren);
   }
   const children = [];
   for (let n = fragment.firstChild; n; n = n.nextSibling) {

--- a/src/custom-elements.js
+++ b/src/custom-elements.js
@@ -23,8 +23,11 @@ if (!priorCustomElements ||
      priorCustomElements['forcePolyfill'] ||
      (typeof priorCustomElements['define'] != 'function') ||
      (typeof priorCustomElements['get'] != 'function')) {
+
+  const preferPerformance = priorCustomElements && priorCustomElements['preferPerformance'];
+
   /** @type {!CustomElementInternals} */
-  const internals = new CustomElementInternals();
+  const internals = new CustomElementInternals(preferPerformance);
 
   PatchHTMLElement(internals);
   PatchDocument(internals);

--- a/src/custom-elements.js
+++ b/src/custom-elements.js
@@ -24,13 +24,13 @@ if (!priorCustomElements ||
      (typeof priorCustomElements['define'] != 'function') ||
      (typeof priorCustomElements['get'] != 'function')) {
 
-  const noConstructionObserver = priorCustomElements && priorCustomElements['noConstructionObserver'];
-  const fastWalk = priorCustomElements && priorCustomElements['fastWalk'];
+  const noDocumentConstructionObserver = priorCustomElements && priorCustomElements['noDocumentConstructionObserver'];
+  const shadyDomFastWalk = priorCustomElements && priorCustomElements['shadyDomFastWalk'];
 
   /** @type {!CustomElementInternals} */
   const internals = new CustomElementInternals({
-    noConstructionObserver,
-    fastWalk
+    noDocumentConstructionObserver,
+    shadyDomFastWalk
   });
 
   PatchHTMLElement(internals);

--- a/src/custom-elements.js
+++ b/src/custom-elements.js
@@ -24,10 +24,16 @@ if (!priorCustomElements ||
      (typeof priorCustomElements['define'] != 'function') ||
      (typeof priorCustomElements['get'] != 'function')) {
 
-  const preferPerformance = priorCustomElements && priorCustomElements['preferPerformance'];
+  const noConstructionObserver = priorCustomElements && priorCustomElements['noConstructionObserver'];
+  const noHtmlImports = priorCustomElements && priorCustomElements['noHtmlImports'];
+  const fastWalk = priorCustomElements && priorCustomElements['fastWalk'];
 
   /** @type {!CustomElementInternals} */
-  const internals = new CustomElementInternals(preferPerformance);
+  const internals = new CustomElementInternals({
+    noConstructionObserver,
+    noHtmlImports,
+    fastWalk
+  });
 
   PatchHTMLElement(internals);
   PatchDocument(internals);

--- a/src/custom-elements.js
+++ b/src/custom-elements.js
@@ -25,13 +25,11 @@ if (!priorCustomElements ||
      (typeof priorCustomElements['get'] != 'function')) {
 
   const noConstructionObserver = priorCustomElements && priorCustomElements['noConstructionObserver'];
-  const noHtmlImports = priorCustomElements && priorCustomElements['noHtmlImports'];
   const fastWalk = priorCustomElements && priorCustomElements['fastWalk'];
 
   /** @type {!CustomElementInternals} */
   const internals = new CustomElementInternals({
     noConstructionObserver,
-    noHtmlImports,
     fastWalk
   });
 


### PR DESCRIPTION
Setting customElements.preferPerformance (1) will use querySelectorAll to find elements to upgrade, connect, and disconnect, (2) does not use the document construction observer to upgrade the document. This setting improves performance but reduces correctness in some cases: (1) removes support for upgrading custom elements inside HTMLImports, (2) does not upgrade undistributed custom elements in polyfilled shadow roots, and (3) elements do not upgrade with Mutation Observer timing, which is less spec correct.