### PR TITLE
Adds `polyfillLazyDefine`

### DIFF
--- a/externs/custom-elements.js
+++ b/externs/custom-elements.js
@@ -15,6 +15,9 @@ CustomElementRegistry.prototype.forcePolyfill;
 /** @type {boolean|undefined} */
 CustomElementRegistry.prototype.preferPerformance;
 
+/** @type {function(string, !Function)|undefined} */
+CustomElementRegistry.prototype.polyfillDefineLazy;
+
 class AlreadyConstructedMarkerType {}
 
 /**
@@ -30,6 +33,14 @@ class AlreadyConstructedMarkerType {}
  * }}
  */
 let CustomElementDefinition;
+
+/**
+ * @typedef {{
+ *  localName: string,
+ *  constructorGetter: !Function
+ * }}
+ */
+let CustomElementLazyDefinition;
 
 
 // These properties are defined in the closure externs so that they will not be

--- a/externs/custom-elements.js
+++ b/externs/custom-elements.js
@@ -12,6 +12,9 @@
 /** @type {boolean|undefined} */
 CustomElementRegistry.prototype.forcePolyfill;
 
+/** @type {boolean|undefined} */
+CustomElementRegistry.prototype.preferPerformance;
+
 class AlreadyConstructedMarkerType {}
 
 /**

--- a/src/CustomElementRegistry.js
+++ b/src/CustomElementRegistry.js
@@ -10,7 +10,6 @@
 
 import CustomElementInternals from './CustomElementInternals.js';
 import DocumentConstructionObserver from './DocumentConstructionObserver.js';
-import Deferred from './Deferred.js';
 import * as Utilities from './Utilities.js';
 
 /**
@@ -22,42 +21,12 @@ export default class CustomElementRegistry {
    * @param {!CustomElementInternals} internals
    */
   constructor(internals) {
-    /**
-     * @private
-     * @type {boolean}
-     */
-    this._elementDefinitionIsRunning = false;
 
     /**
      * @private
      * @type {!CustomElementInternals}
      */
     this._internals = internals;
-
-    /**
-     * @private
-     * @type {!Map<string, !Deferred<undefined>>}
-     */
-    this._whenDefinedDeferred = new Map();
-
-    /**
-     * The default flush callback triggers the document walk synchronously.
-     * @private
-     * @type {!Function}
-     */
-    this._flushCallback = fn => fn();
-
-    /**
-     * @private
-     * @type {boolean}
-     */
-    this._flushPending = false;
-
-    /**
-     * @private
-     * @type {!Array<!CustomElementDefinition>}
-     */
-    this._pendingDefinitions = [];
 
     /**
     * @private
@@ -69,151 +38,37 @@ export default class CustomElementRegistry {
 
   /**
    * @param {string} localName
+   * @param {!Function} constructorOrGetter
+   * @param {boolean} isGetter
+   */
+  _define(localName, constructorOrGetter, isGetter = false) {
+    this._internals.assertCanDefine(localName, constructorOrGetter);
+    const definition = isGetter ?
+      this._internals.setupLazyDefinition(localName, constructorOrGetter) :
+      this._internals.setupDefinition(localName, constructorOrGetter);
+    if (definition) {
+      this._internals.processDefinition(definition);
+    }
+  }
+
+  /**
+   * @param {string} localName
    * @param {!Function} constructor
    */
   define(localName, constructor) {
-    if (!(constructor instanceof Function)) {
-      throw new TypeError('Custom element constructors must be functions.');
-    }
+    this._define(localName, constructor);
+  }
 
-    if (!Utilities.isValidCustomElementName(localName)) {
-      throw new SyntaxError(`The element name '${localName}' is not valid.`);
-    }
-
-    if (this._internals.localNameToDefinition(localName)) {
-      throw new Error(`A custom element with name '${localName}' has already been defined.`);
-    }
-
-    if (this._elementDefinitionIsRunning) {
-      throw new Error('A custom element is already being defined.');
-    }
-    this._elementDefinitionIsRunning = true;
-
-    let connectedCallback;
-    let disconnectedCallback;
-    let adoptedCallback;
-    let attributeChangedCallback;
-    let observedAttributes;
-    try {
-      /** @type {!Object} */
-      const prototype = constructor.prototype;
-      if (!(prototype instanceof Object)) {
-        throw new TypeError('The custom element constructor\'s prototype is not an object.');
-      }
-
-      function getCallback(name) {
-        const callbackValue = prototype[name];
-        if (callbackValue !== undefined && !(callbackValue instanceof Function)) {
-          throw new Error(`The '${name}' callback must be a function.`);
-        }
-        return callbackValue;
-      }
-
-      connectedCallback = getCallback('connectedCallback');
-      disconnectedCallback = getCallback('disconnectedCallback');
-      adoptedCallback = getCallback('adoptedCallback');
-      attributeChangedCallback = getCallback('attributeChangedCallback');
-      observedAttributes = constructor['observedAttributes'] || [];
-    } catch (e) {
-      return;
-    } finally {
-      this._elementDefinitionIsRunning = false;
-    }
-
-    const definition = {
-      localName,
-      constructorFunction: constructor,
-      connectedCallback,
-      disconnectedCallback,
-      adoptedCallback,
-      attributeChangedCallback,
-      observedAttributes,
-      constructionStack: [],
-    };
-
-    this._internals.setDefinition(localName, definition);
-    this._pendingDefinitions.push(definition);
-
-    // If we've already called the flush callback and it hasn't called back yet,
-    // don't call it again.
-    if (!this._flushPending) {
-      this._flushPending = true;
-      this._flushCallback(() => this._flush());
-    }
+  /**
+   * @param {string} localName
+   * @param {!Function} classGetter
+   */
+  polyfillDefineLazy(localName, classGetter) {
+    this._define(localName, classGetter, true);
   }
 
   upgrade(element) {
     this._internals.patchAndUpgradeTree(element);
-  }
-
-  _flush() {
-    // If no new definitions were defined, don't attempt to flush. This could
-    // happen if a flush callback keeps the function it is given and calls it
-    // multiple times.
-    if (this._flushPending === false) return;
-    this._flushPending = false;
-
-    const pendingDefinitions = this._pendingDefinitions;
-
-    /**
-     * Unupgraded elements with definitions that were defined *before* the last
-     * flush, in document order.
-     * @type {!Array<!HTMLElement>}
-     */
-    const elementsWithStableDefinitions = [];
-
-    /**
-     * A map from `localName`s of definitions that were defined *after* the last
-     * flush to unupgraded elements matching that definition, in document order.
-     * @type {!Map<string, !Array<!HTMLElement>>}
-     */
-    const elementsWithPendingDefinitions = new Map();
-    for (let i = 0; i < pendingDefinitions.length; i++) {
-      elementsWithPendingDefinitions.set(pendingDefinitions[i].localName, []);
-    }
-
-    this._internals.patchAndUpgradeTree(document, {
-      upgrade: element => {
-        // Ignore the element if it has already upgraded or failed to upgrade.
-        if (element.__CE_state !== undefined) return;
-
-        const localName = element.localName;
-
-        // If there is an applicable pending definition for the element, add the
-        // element to the list of elements to be upgraded with that definition.
-        const pendingElements = elementsWithPendingDefinitions.get(localName);
-        if (pendingElements) {
-          pendingElements.push(element);
-        // If there is *any other* applicable definition for the element, add it
-        // to the list of elements with stable definitions that need to be upgraded.
-        } else if (this._internals.localNameToDefinition(localName)) {
-          elementsWithStableDefinitions.push(element);
-        }
-      },
-    });
-
-    // Upgrade elements with 'stable' definitions first.
-    for (let i = 0; i < elementsWithStableDefinitions.length; i++) {
-      this._internals.upgradeElement(elementsWithStableDefinitions[i]);
-    }
-
-    // Upgrade elements with 'pending' definitions in the order they were defined.
-    while (pendingDefinitions.length > 0) {
-      const definition = pendingDefinitions.shift();
-      const localName = definition.localName;
-
-      // Attempt to upgrade all applicable elements.
-      const pendingUpgradableElements = elementsWithPendingDefinitions.get(definition.localName);
-      for (let i = 0; i < pendingUpgradableElements.length; i++) {
-        this._internals.upgradeElement(pendingUpgradableElements[i]);
-      }
-
-      // Resolve any promises created by `whenDefined` for the definition.
-      const deferred = this._whenDefinedDeferred.get(localName);
-      if (deferred) {
-        deferred.resolve(undefined);
-      }
-    }
   }
 
   /**
@@ -237,38 +92,24 @@ export default class CustomElementRegistry {
     if (!Utilities.isValidCustomElementName(localName)) {
       return Promise.reject(new SyntaxError(`'${localName}' is not a valid custom element name.`));
     }
-
-    const prior = this._whenDefinedDeferred.get(localName);
-    if (prior) {
-      return prior.toPromise();
-    }
-
-    const deferred = new Deferred();
-    this._whenDefinedDeferred.set(localName, deferred);
-
-    const definition = this._internals.localNameToDefinition(localName);
-    // Resolve immediately only if the given local name has a definition *and*
-    // the full document walk to upgrade elements with that local name has
-    // already happened.
-    if (definition && !this._pendingDefinitions.some(d => d.localName === localName)) {
-      deferred.resolve(undefined);
-    }
-
-    return deferred.toPromise();
+    return this._internals.whenDefined(localName);
   }
 
-  polyfillWrapFlushCallback(outer) {
+  /**
+   * @param {!Function} callback
+   */
+  polyfillWrapFlushCallback(callback) {
     if (this._documentConstructionObserver) {
       this._documentConstructionObserver.disconnect();
     }
-    const inner = this._flushCallback;
-    this._flushCallback = flush => outer(() => inner(flush));
+    this._internals.wrapFlushCallback(callback);
   }
 }
 
 // Closure compiler exports.
 window['CustomElementRegistry'] = CustomElementRegistry;
 CustomElementRegistry.prototype['define'] = CustomElementRegistry.prototype.define;
+CustomElementRegistry.prototype['polyfillDefineLazy'] = CustomElementRegistry.prototype.polyfillDefineLazy;
 CustomElementRegistry.prototype['upgrade'] = CustomElementRegistry.prototype.upgrade;
 CustomElementRegistry.prototype['get'] = CustomElementRegistry.prototype.get;
 CustomElementRegistry.prototype['whenDefined'] = CustomElementRegistry.prototype.whenDefined;

--- a/src/CustomElementRegistry.js
+++ b/src/CustomElementRegistry.js
@@ -60,10 +60,11 @@ export default class CustomElementRegistry {
     this._pendingDefinitions = [];
 
     /**
-     * @private
-     * @type {!DocumentConstructionObserver}
-     */
-    this._documentConstructionObserver = new DocumentConstructionObserver(internals, document);
+    * @private
+    * @type {!DocumentConstructionObserver|undefined}
+    */
+    this._documentConstructionObserver = internals.preferPerformance ?
+      undefined : new DocumentConstructionObserver(internals, document);
   }
 
   /**
@@ -257,7 +258,9 @@ export default class CustomElementRegistry {
   }
 
   polyfillWrapFlushCallback(outer) {
-    this._documentConstructionObserver.disconnect();
+    if (this._documentConstructionObserver) {
+      this._documentConstructionObserver.disconnect();
+    }
     const inner = this._flushCallback;
     this._flushCallback = flush => outer(() => inner(flush));
   }

--- a/src/Patch/Document.js
+++ b/src/Patch/Document.js
@@ -27,7 +27,8 @@ export default function(internals) {
     function(localName) {
       // Only create custom elements if this document is associated with the registry.
       if (this.__CE_hasRegistry) {
-        const definition = internals.localNameToDefinition(localName);
+        const definition = internals.localNameToDefinition(localName) ||
+          internals.flushLazyDefinition(localName);
         if (definition) {
           return new (definition.constructorFunction)();
         }
@@ -69,7 +70,8 @@ export default function(internals) {
     function(namespace, localName) {
       // Only create custom elements if this document is associated with the registry.
       if (this.__CE_hasRegistry && (namespace === null || namespace === NS_HTML)) {
-        const definition = internals.localNameToDefinition(localName);
+        let definition = internals.localNameToDefinition(localName)  ||
+          internals.flushLazyDefinition(localName);
         if (definition) {
           return new (definition.constructorFunction)();
         }

--- a/src/Patch/Element.js
+++ b/src/Patch/Element.js
@@ -53,8 +53,9 @@ export default function(internals) {
         let removedElements = undefined;
         if (isConnected) {
           removedElements = [];
-          Utilities.walkDeepDescendantElements(this, element => {
-            if (element !== this) {
+          internals.forEachElement(this, element => {
+            if (element !== this &&
+                internals.localNameToDefinition(element.localName)) {
               removedElements.push(element);
             }
           });

--- a/src/PendingLazyDefinitionMarker.js
+++ b/src/PendingLazyDefinitionMarker.js
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+/**
+ * This class exists only to work around Closure's lack of a way to describe
+ * singletons. It represents a token to describe that a definition is pending.
+ */
+class PendingLazyDefinitionMarker {}
+
+export default new PendingLazyDefinitionMarker();

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -35,6 +35,13 @@ const nativeContains = document.contains ? document.contains.bind(document) :
 
 /**
  * @param {!Node} node
+ */
+export function isElementOrShadowRoot(node) {
+  return (node instanceof Element || node instanceof ShadowRoot);
+}
+
+/**
+ * @param {!Node} node
  * @return {boolean}
  */
 export function isConnected(node) {
@@ -54,6 +61,23 @@ export function isConnected(node) {
     current = current.parentNode || (window.ShadowRoot && current instanceof ShadowRoot ? current.host : undefined);
   }
   return !!(current && (current.__CE_isImportDocument || current instanceof Document));
+}
+
+/**
+ * @param {!DocumentFragment} fragment
+ * @return {!Array<!Element>}
+ */
+export function childrenFromFragment(fragment) {
+  if (fragment.children) {
+    return Array.prototype.slice.call(fragment.children);
+  }
+  const children = [];
+  for (let n = fragment.firstChild; n; n = n.nextSibling) {
+    if (n.nodeType === Node.ELEMENT_NODE) {
+      children.push(n);
+    }
+  }
+  return children;
 }
 
 /**

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -68,6 +68,7 @@ export function isConnected(node) {
  * @return {!Array<!Element>}
  */
 export function childrenFromFragment(fragment) {
+  // Note, IE doesn't have `children` on document fragments.
   if (fragment.children) {
     return Array.prototype.slice.call(fragment.children);
   }

--- a/src/custom-elements.js
+++ b/src/custom-elements.js
@@ -23,8 +23,11 @@ if (!priorCustomElements ||
      priorCustomElements['forcePolyfill'] ||
      (typeof priorCustomElements['define'] != 'function') ||
      (typeof priorCustomElements['get'] != 'function')) {
+
+  const preferPerformance = priorCustomElements && priorCustomElements['preferPerformance'];
+
   /** @type {!CustomElementInternals} */
-  const internals = new CustomElementInternals();
+  const internals = new CustomElementInternals(preferPerformance);
 
   PatchHTMLElement(internals);
   PatchDocument(internals);

--- a/tests/index.html
+++ b/tests/index.html
@@ -27,6 +27,7 @@
     'js/closure.js',
     'js/upgrade.js',
     'js/shadow-dom.js',
+    'js/polyfill-lazy-define.js',
     'html/registry-upgrade.html',
     'html/polyfillWrapFlushCallback/index.html',
     'html/imports.html',

--- a/tests/js/polyfill-lazy-define.js
+++ b/tests/js/polyfill-lazy-define.js
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+suite('polyfillLazyDefine', function() {
+  var work;
+  var assert = chai.assert;
+  var HTMLNS = 'http://www.w3.org/1999/xhtml';
+
+  customElements.enableFlush = true;
+
+  setup(function() {
+    work = document.createElement('div');
+    document.body.appendChild(work);
+  });
+
+  teardown(function() {
+    document.body.removeChild(work);
+  });
+
+  suite('defining', function() {
+
+    test('requires a name argument', function() {
+      assert.throws(function() {
+        customElements.polyfillDefineLazy();
+      }, '', 'customElements.define failed to throw when given no arguments');
+    });
+
+    test('name must contain a dash', function() {
+      assert.throws(function () {
+        customElements.polyfillDefineLazy('xfoo', () => {prototype: Object.create(HTMLElement.prototype)});
+      }, '', 'customElements.define failed to throw when given no arguments');
+    });
+
+    test('name must not be a reserved name', function() {
+      assert.throws(function() {
+        customElements.polyfillDefineLazy('font-face', () => {prototype: Object.create(HTMLElement.prototype)});
+      }, '', 'Failed to execute \'defineElement\' on \'Document\': Registration failed for type \'font-face\'. The type name is invalid.');
+    });
+
+    test('name must be unique', function() {
+      const generator = () => class XDuplicate extends HTMLElement {};
+      customElements.polyfillDefineLazy('x-lazy-duplicate', generator);
+      assert.throws(function() {
+        customElements.polyfillDefineLazy('x-lazy-duplicate', generator);
+      }, '', 'customElements.define failed to throw when called multiple times with the same element name');
+    });
+
+    test('name must be unique and not defined', function() {
+      customElements.define('x-lazy-duplicate-define', class extends HTMLElement {});
+      assert.throws(function() {
+        customElements.polyfillDefineLazy('x-lazy-duplicate-define', () => class extends HTMLElement {});
+      }, '', 'customElements.define failed to throw when called multiple times with the same element name');
+    });
+
+    test('names are case-sensitive', function() {
+      const generator = () => class XCase extends HTMLElement {};
+      assert.throws(function() { customElements.polyfillDefineLazy('X-CASE', generator); });
+    });
+
+    test('requires a constructor argument', function() {
+      assert.throws(function () {
+        customElements.polyfillDefineLazy('x-no-options');
+      }, '', 'customElements.define failed to throw without a constructor argument');
+    });
+
+  });
+
+  suite('get', function() {
+
+    test('returns undefined and constructor after element upgrades', function() {
+      customElements.polyfillDefineLazy('x-get-lazy', () => class extends HTMLElement {});
+      assert.isUndefined(customElements.get('x-get-lazy'));
+      document.createElement('x-get-lazy');
+      assert.ok(customElements.get('x-get-lazy'));
+    });
+
+  });
+
+  suite('whenDefined', function() {
+
+    test('resolves when a lazy define is first upgraded', function() {
+      customElements.polyfillDefineLazy('x-when-defined-lazy', () =>class extends HTMLElement {});
+      const el = document.createElement('x-when-defined-lazy');
+      work.appendChild(el);
+      return customElements.whenDefined('x-when-defined-lazy');
+    });
+
+    test('resolves when a lazy define promise is first upgraded', function() {
+      customElements.polyfillDefineLazy('x-when-defined-lazy-promise', () =>
+        new Promise((resolve) => resolve(class extends HTMLElement {})));
+      const el = document.createElement('x-when-defined-lazy-promise');
+      work.appendChild(el);
+      return customElements.whenDefined('x-when-defined-lazy-promise');
+    });
+
+  });
+
+  suite('upgrades', function() {
+
+    test('createElement upgrades when defined (without promise)', function() {
+      customElements.polyfillDefineLazy('lazy-create-upgrade', () => {
+        return class extends HTMLElement {
+          constructor() {
+            super();
+            this.upgraded = true;
+          }
+        }
+      });
+      const el = document.createElement('lazy-create-upgrade');
+      assert.isTrue(el.upgraded);
+    });
+
+    test('createElement/connect upgrades when defined (with promise)', function(done) {
+      customElements.polyfillDefineLazy('lazy-promise-create-upgrade', () =>
+        new Promise((resolve) => resolve(class extends HTMLElement {
+          constructor() {
+            super();
+            this.upgraded = true;
+          }
+          connectedCallback() {
+            this.connected = true;
+          }
+        })));
+      const el = document.createElement('lazy-promise-create-upgrade');
+      work.appendChild(el);
+      customElements.whenDefined('lazy-promise-create-upgrade').then(() => {
+        assert.isTrue(el.upgraded);
+        assert.isTrue(el.connected);
+        done();
+      });
+
+    });
+
+    test('element in dom upgrades (without promise)', function() {
+      const el = document.createElement('lazy-dom-upgrade');
+      work.appendChild(el);
+      customElements.polyfillDefineLazy('lazy-dom-upgrade', () => {
+        return class extends HTMLElement {
+          constructor() {
+            super();
+            this.upgraded = true;
+          }
+          connectedCallback() {
+            this.connected = true;
+          }
+        }
+      });
+      assert.isTrue(el.upgraded);
+      assert.isTrue(el.connected);
+    });
+
+    test('element in dom upgrades (with promise)', function(done) {
+      const el = document.createElement('lazy-promise-dom-upgrade');
+      work.appendChild(el);
+      customElements.polyfillDefineLazy('lazy-promise-dom-upgrade', () =>
+        new Promise((resolve) => resolve(class extends HTMLElement {
+          constructor() {
+            super();
+            this.upgraded = true;
+          }
+          connectedCallback() {
+            this.connected = true;
+          }
+        })));
+      customElements.whenDefined('lazy-promise-dom-upgrade').then(() => {
+        assert.isTrue(el.upgraded);
+        assert.isTrue(el.connected);
+        done();
+      });
+    });
+
+   });
+
+});


### PR DESCRIPTION
Note, based on https://github.com/webcomponents/custom-elements/pull/202 which should be addressed before this.

Fixes #200 by adding customElements.polyfillDefineLazy(name, constructorGenerator) and adds a preferPerformance option.

The customElements.polyfillDefineLazy is an approximation of a potential spec feature to allow definitions to be processed lazily when the first element to customize is found. The constructorGenerator is a function that's invoked only the first time and element to customize is found. It can return an element constructor function or a promise that resolves to an element constructor function.