### PR TITLE
Adds `customElements.polyfillDefineLazy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,24 @@ customElements.define('c-e', class extends HTMLElement {});
 // The document is walked to attempt upgrades.
 ```
 
+### `customElements.polyfillDefineLazy`
+
+Allows defining an element with a constructor getter function that returns an
+element constructor. It provides a small optimization over using
+`customElements.define` when producing the element class is expensive. The
+constructor getter function is called only the first time the polyfill tries
+to upgrade the given element.
+
+```javascript
+customElements.polyfillDefineLazy('c-e', () => {
+  // do some expensive work then...
+  return class extends HTMLElement {};
+});
+```
+
+Note, this API is not included in the custom elements spec and therefore
+requires use of the polyfill to function correctly.
+
 ### Settings
 
 The polyfill provides a few settings to improve performance by tweaking behavior.

--- a/externs/custom-elements.js
+++ b/externs/custom-elements.js
@@ -23,7 +23,7 @@ class AlreadyConstructedMarkerType {}
 /**
  * @typedef {{
  *   localName: string,
- * definition: !CustomElementDefinition
+ *   definition: !CustomElementDefinition
  * }}
  */
 let CustomElementDefinitionProducer;

--- a/externs/custom-elements.js
+++ b/externs/custom-elements.js
@@ -22,7 +22,7 @@ class AlreadyConstructedMarkerType {}
 
 /**
  * @typedef {{
- * localName: string,
+ *   localName: string,
  * definition: !CustomElementDefinition
  * }}
  */

--- a/externs/custom-elements.js
+++ b/externs/custom-elements.js
@@ -36,7 +36,7 @@ let CustomElementCallbacks;
  *  isComplete: boolean,
  *  localName: string,
  *  constructorFunction: !Function,
- *  callbacks: (CustomElementCallbacks|undefined),
+ *  callbacks: (!CustomElementCallbacks|undefined),
  *  constructionStack: !Array<!HTMLElement|!AlreadyConstructedMarkerType>,
  * }}
  */
@@ -76,3 +76,7 @@ Element.prototype.__CE_definition;
 
 /** @type {!DocumentFragment|undefined} */
 Element.prototype.__CE_shadowRoot;
+
+// Note, the closure type is incorrect here.
+/** @type {!HTMLCollection} */
+DocumentFragment.prototype.children;

--- a/externs/custom-elements.js
+++ b/externs/custom-elements.js
@@ -22,13 +22,21 @@ class AlreadyConstructedMarkerType {}
 
 /**
  * @typedef {{
- *  localName: string,
- *  constructorFunction: !Function,
  *  connectedCallback: Function,
  *  disconnectedCallback: Function,
  *  adoptedCallback: Function,
  *  attributeChangedCallback: Function,
  *  observedAttributes: !Array<string>,
+ * }}
+ */
+let CustomElementCallbacks;
+
+/**
+ * @typedef {{
+ *  isComplete: boolean,
+ *  localName: string,
+ *  constructorFunction: !Function,
+ *  callbacks: (CustomElementCallbacks|undefined),
  *  constructionStack: !Array<!HTMLElement|!AlreadyConstructedMarkerType>,
  * }}
  */

--- a/externs/custom-elements.js
+++ b/externs/custom-elements.js
@@ -22,21 +22,21 @@ class AlreadyConstructedMarkerType {}
 
 /**
  * @typedef {{
+ * localName: string,
+ * definition: !CustomElementDefinition
+ * }}
+ */
+let CustomElementDefinitionProducer;
+
+/**
+ * @typedef {{
+ *  localName: string,
+ *  constructorFunction: !Function,
  *  connectedCallback: Function,
  *  disconnectedCallback: Function,
  *  adoptedCallback: Function,
  *  attributeChangedCallback: Function,
  *  observedAttributes: !Array<string>,
- * }}
- */
-let CustomElementCallbacks;
-
-/**
- * @typedef {{
- *  isComplete: boolean,
- *  localName: string,
- *  constructorFunction: !Function,
- *  callbacks: (!CustomElementCallbacks|undefined),
  *  constructionStack: !Array<!HTMLElement|!AlreadyConstructedMarkerType>,
  * }}
  */

--- a/src/CustomElementDefinitionProducer.js
+++ b/src/CustomElementDefinitionProducer.js
@@ -145,7 +145,7 @@ export default class CustomElementDefinitionProducer {
       attributeChangedCallback,
       observedAttributes,
       constructionStack: []
-    }
+    };
 
     this._internals.setDefinitionConstructor(this._definition);
 

--- a/src/CustomElementDefinitionProducer.js
+++ b/src/CustomElementDefinitionProducer.js
@@ -15,7 +15,6 @@ let elementDefinitionIsRunning = false;
 export default class CustomElementDefinitionProducer {
 
   /**
-   *
    * @param {string} localName
    * @param {!Function} constructorOrGetter
    * @param {boolean} isGetter

--- a/src/CustomElementDefinitionProducer.js
+++ b/src/CustomElementDefinitionProducer.js
@@ -8,7 +8,7 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 import CustomElementInternals from './CustomElementInternals.js';
- import * as Utilities from './Utilities.js';
+import * as Utilities from './Utilities.js';
 
 let elementDefinitionIsRunning = false;
 

--- a/src/CustomElementDefinitionProducer.js
+++ b/src/CustomElementDefinitionProducer.js
@@ -50,8 +50,8 @@ export default class CustomElementDefinitionProducer {
      */
     this._definition = undefined;
 
-    if (!(constructorOrGetter instanceof Function)) {
-      throw new TypeError('Custom element constructors must be functions.');
+    if (this._isGetter && !(constructorOrGetter instanceof Function)) {
+      throw new TypeError('Custom element constructor getters must be functions.');
     }
 
     if (!Utilities.isValidCustomElementName(localName)) {

--- a/src/CustomElementDefinitionProducer.js
+++ b/src/CustomElementDefinitionProducer.js
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+import CustomElementInternals from './CustomElementInternals.js';
+ import * as Utilities from './Utilities.js';
+
+let elementDefinitionIsRunning = false;
+
+/**
+ * @unrestricted
+ */
+export default class CustomElementDefinitionProducer {
+
+  /**
+   *
+   * @param {string} localName
+   * @param {!Function} constructorOrGetter
+   * @param {boolean} isGetter
+   * @param {!CustomElementInternals} internals
+   */
+  constructor(localName, constructorOrGetter, isGetter, internals) {
+
+    /**
+     * @private
+     * @const {!CustomElementInternals}
+     */
+    this._internals = internals;
+
+    /**
+     * @private
+     * @const {!Function}
+     */
+    this._constructorOrGetter = constructorOrGetter;
+
+    /**
+     * @private
+     * @const {boolean}
+     */
+    this._isGetter = isGetter;
+
+    /** @const {string} */
+    this.localName = localName;
+
+    /**
+     * @private
+     * @type {!CustomElementDefinition|undefined}
+     */
+    this._definition;
+
+    if (!(constructorOrGetter instanceof Function)) {
+      throw new TypeError('Custom element constructors must be functions.');
+    }
+
+    if (!Utilities.isValidCustomElementName(localName)) {
+      throw new SyntaxError(`The element name '${localName}' is not valid.`);
+    }
+
+    if (this._internals.localNameToDefinitionProducer(localName)) {
+      throw new Error(`A custom element with name '${localName}' has already been defined.`);
+    }
+
+    if (elementDefinitionIsRunning) {
+      throw new Error('A custom element is already being defined.');
+    }
+
+    // Per spec, reify the definition immediately if possible.
+    if (!this._isGetter) {
+      this._ensureDefinition();
+    }
+  }
+
+  /** @return {!CustomElementDefinition} */
+  get definition() {
+    this._ensureDefinition();
+    return /** @type {!CustomElementDefinition} */ (this._definition);
+  }
+
+  _ensureDefinition() {
+    if (this._definition) {
+      return;
+    }
+    elementDefinitionIsRunning = true;
+    let connectedCallback;
+    let disconnectedCallback;
+    let adoptedCallback;
+    let attributeChangedCallback;
+    let observedAttributes;
+    let constructorFunction;
+    let error;
+    try {
+      constructorFunction = this._isGetter ? this._constructorOrGetter() :
+        this._constructorOrGetter;
+      /** @type {!Object} */
+      const prototype = constructorFunction.prototype;
+      if (!(prototype instanceof Object)) {
+        throw new TypeError('The custom element constructor\'s prototype is not an object.');
+      }
+
+      function getCallback(name) {
+        const callbackValue = prototype[name];
+        if (callbackValue !== undefined && !(callbackValue instanceof Function)) {
+          throw new Error(`The '${name}' callback must be a function.`);
+        }
+        return callbackValue;
+      }
+      connectedCallback = getCallback('connectedCallback');
+      disconnectedCallback = getCallback('disconnectedCallback');
+      adoptedCallback = getCallback('adoptedCallback');
+      attributeChangedCallback = getCallback('attributeChangedCallback');
+      observedAttributes = constructorFunction['observedAttributes'] || [];
+    } catch (e) {
+    } finally {
+      elementDefinitionIsRunning = false;
+    }
+
+    this._definition = {
+      localName: this.localName,
+      constructorFunction,
+      connectedCallback,
+      disconnectedCallback,
+      adoptedCallback,
+      attributeChangedCallback,
+      observedAttributes,
+      constructionStack: []
+    }
+
+    this._internals.setDefinitionConstructor(this._definition);
+  }
+
+}

--- a/src/CustomElementDefinitionProducer.js
+++ b/src/CustomElementDefinitionProducer.js
@@ -12,9 +12,6 @@ import CustomElementInternals from './CustomElementInternals.js';
 
 let elementDefinitionIsRunning = false;
 
-/**
- * @unrestricted
- */
 export default class CustomElementDefinitionProducer {
 
   /**
@@ -51,7 +48,7 @@ export default class CustomElementDefinitionProducer {
      * @private
      * @type {!CustomElementDefinition|undefined}
      */
-    this._definition;
+    this._definition = undefined;
 
     if (!(constructorOrGetter instanceof Function)) {
       throw new TypeError('Custom element constructors must be functions.');
@@ -77,13 +74,13 @@ export default class CustomElementDefinitionProducer {
 
   /** @return {!CustomElementDefinition} */
   get definition() {
-    this._ensureDefinition();
-    return /** @type {!CustomElementDefinition} */ (this._definition);
+    return this._ensureDefinition();
   }
 
+  /** @return {!CustomElementDefinition} */
   _ensureDefinition() {
     if (this._definition) {
-      return;
+      return this._definition;
     }
     elementDefinitionIsRunning = true;
     let connectedCallback;
@@ -92,7 +89,6 @@ export default class CustomElementDefinitionProducer {
     let attributeChangedCallback;
     let observedAttributes;
     let constructorFunction;
-    let error;
     try {
       constructorFunction = this._isGetter ? this._constructorOrGetter() :
         this._constructorOrGetter;
@@ -131,6 +127,8 @@ export default class CustomElementDefinitionProducer {
     }
 
     this._internals.setDefinitionConstructor(this._definition);
+
+    return this._definition;
   }
 
 }

--- a/src/CustomElementInternals.js
+++ b/src/CustomElementInternals.js
@@ -35,9 +35,6 @@ export default class CustomElementInternals {
     /** @type {boolean} */
     this._hasPatches = false;
 
-    /** @type {boolean} */
-    this.elementDefinitionIsRunning = false;
-
     /** @const {boolean} */
     this.shadyDomFastWalk = options.shadyDomFastWalk;
 

--- a/src/CustomElementInternals.js
+++ b/src/CustomElementInternals.js
@@ -54,6 +54,13 @@ export default class CustomElementInternals {
   }
 
   /**
+   * @param {string} localName
+   */
+  removeDefinitionProducer(localName) {
+    this._localNameToDefinitionProducer.delete(localName);
+  }
+
+  /**
    * @param {!CustomElementDefinition} definition
    */
   setDefinitionConstructor(definition) {

--- a/src/CustomElementInternals.js
+++ b/src/CustomElementInternals.js
@@ -333,19 +333,16 @@ export default class CustomElementInternals {
 
     definition.constructionStack.push(element);
 
-    const constructor = definition.constructorFunction;
     try {
-      try {
-        let result = new (constructor)();
-        if (result !== element) {
-          throw new Error('The custom element constructor did not produce the element being upgraded.');
-        }
-      } finally {
-        definition.constructionStack.pop();
+      let result = new (definition.constructorFunction)();
+      if (result !== element) {
+        throw new Error('The custom element constructor did not produce the element being upgraded.');
       }
     } catch (e) {
       element.__CE_state = CEState.failed;
       throw e;
+    } finally {
+      definition.constructionStack.pop();
     }
 
     element.__CE_state = CEState.custom;

--- a/src/CustomElementRegistry.js
+++ b/src/CustomElementRegistry.js
@@ -79,7 +79,7 @@ export default class CustomElementRegistry {
       throw new Error(`A custom element with name '${localName}' has already been defined.`);
     }
 
-    if (this._internals.addingDefinitionCallbacks) {
+    if (this._internals.elementDefinitionIsRunning) {
       throw new Error('A custom element is already being defined.');
     }
 

--- a/src/CustomElementRegistry.js
+++ b/src/CustomElementRegistry.js
@@ -69,7 +69,6 @@ export default class CustomElementRegistry {
     const definitionProducer = new CustomElementDefinitionProducer(
       localName, constructorOrGetter, isGetter, this._internals);
 
-    this._internals.setDefinitionProducer(localName, definitionProducer);
     this._pendingDefinitionProducers.push(definitionProducer);
 
     // If we've already called the flush callback and it hasn't called back yet,

--- a/src/CustomElementRegistry.js
+++ b/src/CustomElementRegistry.js
@@ -14,9 +14,6 @@ import DocumentConstructionObserver from './DocumentConstructionObserver.js';
 import Deferred from './Deferred.js';
 import * as Utilities from './Utilities.js';
 
-/**
- * @unrestricted
- */
 export default class CustomElementRegistry {
 
   /**
@@ -83,10 +80,18 @@ export default class CustomElementRegistry {
     }
   }
 
+  /**
+   * @param {string} localName
+   * @param {!Function} constructor
+   */
   define(localName, constructor) {
     this._define(localName, constructor, false);
   }
 
+  /**
+   * @param {string} localName
+   * @param {!Function} constructorGetter
+   */
   polyfillDefineLazy(localName, constructorGetter) {
     this._define(localName, constructorGetter, true);
   }

--- a/src/Patch/Document.js
+++ b/src/Patch/Document.js
@@ -27,8 +27,7 @@ export default function(internals) {
     function(localName) {
       // Only create custom elements if this document is associated with the registry.
       if (this.__CE_hasRegistry) {
-        const definition = internals.localNameToDefinition(localName);
-        internals.ensureDefinitionComplete(definition);
+        const definition = internals.localNameToCompleteDefinition(localName);
         if (definition) {
           return new (definition.constructorFunction)();
         }
@@ -70,8 +69,7 @@ export default function(internals) {
     function(namespace, localName) {
       // Only create custom elements if this document is associated with the registry.
       if (this.__CE_hasRegistry && (namespace === null || namespace === NS_HTML)) {
-        const definition = internals.localNameToDefinition(localName);
-        internals.ensureDefinitionComplete(definition);
+        const definition = internals.localNameToCompleteDefinition(localName);
         if (definition) {
           return new (definition.constructorFunction)();
         }

--- a/src/Patch/Document.js
+++ b/src/Patch/Document.js
@@ -29,7 +29,9 @@ export default function(internals) {
       if (this.__CE_hasRegistry) {
         const definition = internals.localNameToDefinition(localName);
         if (definition) {
-          return new (definition.constructorFunction)();
+          const element = new (definition.constructorFunction)();
+          Utilities.assertIsHTMLElement(element, localName);
+          return element;
         }
       }
 
@@ -71,7 +73,9 @@ export default function(internals) {
       if (this.__CE_hasRegistry && (namespace === null || namespace === NS_HTML)) {
         const definition = internals.localNameToDefinition(localName);
         if (definition) {
-          return new (definition.constructorFunction)();
+          const element = new (definition.constructorFunction)();
+          Utilities.assertIsHTMLElement(element, localName);
+          return element;
         }
       }
 

--- a/src/Patch/Document.js
+++ b/src/Patch/Document.js
@@ -27,7 +27,7 @@ export default function(internals) {
     function(localName) {
       // Only create custom elements if this document is associated with the registry.
       if (this.__CE_hasRegistry) {
-        const definition = internals.localNameToCompleteDefinition(localName);
+        const definition = internals.localNameToDefinition(localName);
         if (definition) {
           return new (definition.constructorFunction)();
         }
@@ -69,7 +69,7 @@ export default function(internals) {
     function(namespace, localName) {
       // Only create custom elements if this document is associated with the registry.
       if (this.__CE_hasRegistry && (namespace === null || namespace === NS_HTML)) {
-        const definition = internals.localNameToCompleteDefinition(localName);
+        const definition = internals.localNameToDefinition(localName);
         if (definition) {
           return new (definition.constructorFunction)();
         }

--- a/src/Patch/Document.js
+++ b/src/Patch/Document.js
@@ -28,6 +28,7 @@ export default function(internals) {
       // Only create custom elements if this document is associated with the registry.
       if (this.__CE_hasRegistry) {
         const definition = internals.localNameToDefinition(localName);
+        internals.ensureDefinitionComplete(definition);
         if (definition) {
           return new (definition.constructorFunction)();
         }
@@ -70,6 +71,7 @@ export default function(internals) {
       // Only create custom elements if this document is associated with the registry.
       if (this.__CE_hasRegistry && (namespace === null || namespace === NS_HTML)) {
         const definition = internals.localNameToDefinition(localName);
+        internals.ensureDefinitionComplete(definition);
         if (definition) {
           return new (definition.constructorFunction)();
         }

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -20,6 +20,17 @@ const reservedTagList = new Set([
 ]);
 
 /**
+ *
+ * @param {HTMLElement} element
+ * @param {string} localName
+ */
+export function assertIsHTMLElement(element, localName) {
+  if (!(element instanceof HTMLElement)) {
+    throw new Error(`Failed to construct 'CustomElement' ${localName}: The result must implement HTMLElement interface.`);
+  }
+}
+
+/**
  * @param {string} localName
  * @returns {boolean}
  */

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -20,17 +20,6 @@ const reservedTagList = new Set([
 ]);
 
 /**
- *
- * @param {HTMLElement} element
- * @param {string} localName
- */
-export function assertIsHTMLElement(element, localName) {
-  if (!(element instanceof HTMLElement)) {
-    throw new Error(`Failed to construct 'CustomElement' ${localName}: The result must implement HTMLElement interface.`);
-  }
-}
-
-/**
  * @param {string} localName
  * @returns {boolean}
  */

--- a/tests/html/HTMLElement/constructor.html
+++ b/tests/html/HTMLElement/constructor.html
@@ -88,6 +88,8 @@ suite('Constructing elements', function() {
             createSelf = false;
             new UnconstructableCustomElement();
           }
+
+          super();
         }
       }
       customElements.define('unconstructable-custom-element',
@@ -122,6 +124,21 @@ suite('Constructing elements', function() {
         const templateContent =
             document.querySelector('#non-conformant-custom-element').content;
         document.importNode(templateContent, true);
+      });
+    });
+
+  test('Non-conformant custom element constructors that return a different ' +
+    'element throw.', function() {
+      class NonConformantCustomElement2 extends HTMLElement {
+        constructor() {
+          return document.createElement('div');
+        }
+      }
+      customElements.define('non-conformant-custom-element-2',
+          NonConformantCustomElement2);
+
+      assert.throws(function() {
+        document.createElement('non-conformant-custom-element-2');
       });
     });
 });

--- a/tests/html/HTMLElement/constructor.html
+++ b/tests/html/HTMLElement/constructor.html
@@ -11,8 +11,12 @@
 </head>
 <body>
 
-<template id="bad-custom-element-1">
-  <bad-custom-element-1></bad-custom-element-1>
+<template id="unconstructable-custom-element">
+  <unconstructable-custom-element></unconstructable-custom-element>
+</template>
+
+<template id="non-conformant-custom-element">
+  <non-conformant-custom-element></non-conformant-custom-element>
 </template>
 
 <script>
@@ -72,23 +76,52 @@ suite('Constructing elements', function() {
       });
     });
 
-  test('Custom element constructors may not cause more instances of the same ' +
-    'custom element to be created before calling into `HTMLElement` (e.g. via ' +
-    '`super()`).', function() {
+  test('Non-conformant custom element constructors that attempt to construct ' +
+    'more instances of themselves using `new` before calling into ' +
+    '`HTMLElement` (e.g. via `super()`) cause an error to be thrown when the ' +
+    '`HTMLElement` constructor finds the AlreadyConstructedMarker.',
+    function() {
       let createSelf = true;
-      customElements.define('bad-custom-element-1', class extends HTMLElement {
+      class UnconstructableCustomElement extends HTMLElement {
         constructor() {
           if (createSelf) {
             createSelf = false;
-            document.createElement('bad-custom-element-1');
+            new UnconstructableCustomElement();
+          }
+        }
+      }
+      customElements.define('unconstructable-custom-element',
+          UnconstructableCustomElement);
+
+      assert.throws(function() {
+        const templateContent =
+            document.querySelector('#unconstructable-custom-element').content;
+        document.importNode(templateContent, true);
+      });
+    });
+
+  test('Non-conformant custom element constructors that attempt to create ' +
+    'more instances of themselves using `Document#createElement` before ' +
+    'calling into `HTMLElement` (e.g. via `super()`) do NOT cause an error ' +
+    'to be thrown.', function() {
+      let createSelf = true;
+      class NonConformantCustomElement extends HTMLElement {
+        constructor() {
+          if (createSelf) {
+            createSelf = false;
+            document.createElement('non-conformant-custom-element');
           }
 
           super();
         }
-      });
+      }
+      customElements.define('non-conformant-custom-element',
+          NonConformantCustomElement);
 
-      assert.throws(function() {
-        document.importNode(document.querySelector('#bad-custom-element-1').content, true);
+      assert.doesNotThrow(function() {
+        const templateContent =
+            document.querySelector('#non-conformant-custom-element').content;
+        document.importNode(templateContent, true);
       });
     });
 });

--- a/tests/index.html
+++ b/tests/index.html
@@ -27,6 +27,7 @@
     'js/closure.js',
     'js/upgrade.js',
     'js/shadow-dom.js',
+    'js/polyfill-define-lazy.js',
     'html/registry-upgrade.html',
     'html/polyfillWrapFlushCallback/index.html',
     'html/imports.html',

--- a/tests/js/polyfill-define-lazy.js
+++ b/tests/js/polyfill-define-lazy.js
@@ -11,7 +11,6 @@
 suite('polyfillLazyDefine', function() {
   var work;
   var assert = chai.assert;
-  var HTMLNS = 'http://www.w3.org/1999/xhtml';
 
   customElements.enableFlush = true;
 

--- a/tests/js/polyfill-define-lazy.js
+++ b/tests/js/polyfill-define-lazy.js
@@ -74,21 +74,19 @@ suite('polyfillLazyDefine', function() {
 
   suite('get', function() {
 
-    test('returns undefined and constructor after element upgrades', function() {
-      customElements.polyfillDefineLazy('x-get-lazy', () => class extends HTMLElement {});
-      assert.isUndefined(customElements.get('x-get-lazy'));
-      document.createElement('x-get-lazy');
-      assert.ok(customElements.get('x-get-lazy'));
+    test('returns constructor', function() {
+      const ctor = class extends HTMLElement {};
+      customElements.polyfillDefineLazy('x-get-lazy', () => ctor);
+      assert.equal(customElements.get('x-get-lazy'), ctor);
     });
 
   });
 
   suite('whenDefined', function() {
 
-    test('resolves when a lazy define is first upgraded', function() {
-      customElements.polyfillDefineLazy('x-when-defined-lazy', () =>class extends HTMLElement {});
-      const el = document.createElement('x-when-defined-lazy');
-      work.appendChild(el);
+    test('resolves', function() {
+      const ctor = class extends HTMLElement {};
+      customElements.polyfillDefineLazy('x-when-defined-lazy', () => ctor);
       return customElements.whenDefined('x-when-defined-lazy');
     });
 
@@ -125,6 +123,17 @@ suite('polyfillLazyDefine', function() {
       });
       assert.isTrue(el.upgraded);
       assert.isTrue(el.connected);
+    });
+
+    test('creating an element throws if a constructor getter is used with `define`', function() {
+      customElements.define('pass-getter-to-define', () => {});
+      let error;
+      try {
+        document.createElement('pass-getter-to-define');
+      } catch (e) {
+        error = e;
+      }
+      assert.ok(error);
     });
 
    });

--- a/tests/js/polyfill-define-lazy.js
+++ b/tests/js/polyfill-define-lazy.js
@@ -70,6 +70,41 @@ suite('polyfillLazyDefine', function() {
       }, '', 'customElements.define failed to throw without a constructor argument');
     });
 
+    test('define succeeds with named used for a polyfillDefineLazy with an invalid class', function() {
+      customElements.polyfillDefineLazy('x-failed-define-lazy', () => {});
+      // Work around for console.error being considered an error.
+      sinon.spy(console, 'error');
+      let error;
+      try {
+        customElements.define('x-failed-define-lazy', class extends HTMLElement {});
+      } catch (e) {
+        error = !!(e && !console.error.called);
+      }
+      assert.isFalse(error, 'Error thrown when defining an element using the same name as a failed definition with an invalid class.')
+      console.error.restore();
+    });
+
+    test('define succeeds with named used for a polyfillDefineLazy with invalid callbacks', function() {
+      try {
+        customElements.polyfillDefineLazy('x-failed-define-lazy-callbacks', () => class extends HTMLElement {
+          attributeChangedCallback() {}
+          static get observedAttributes() {
+            throw new Error('no attributes');
+          }
+        });
+      } catch (e) {}
+      // Work around for console.error being considered an error.
+      sinon.spy(console, 'error');
+      let error;
+      try {
+        customElements.define('x-failed-define-lazy-callbacks', class extends HTMLElement {});
+      } catch (e) {
+        error = !!(e && !console.error.called);
+      }
+      assert.isFalse(error, 'Error thrown when defining an element using the same name as a failed definition with invalid callbacks.')
+      console.error.restore();
+    });
+
   });
 
   suite('get', function() {
@@ -126,7 +161,7 @@ suite('polyfillLazyDefine', function() {
     });
 
     test('creating an element throws if a constructor getter is used with `define`', function() {
-      customElements.define('pass-getter-to-define', () => {});
+      customElements.define('pass-getter-to-define', function() {});
       let error;
       try {
         document.createElement('pass-getter-to-define');

--- a/tests/js/polyfill-define-lazy.js
+++ b/tests/js/polyfill-define-lazy.js
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+suite('polyfillLazyDefine', function() {
+  var work;
+  var assert = chai.assert;
+  var HTMLNS = 'http://www.w3.org/1999/xhtml';
+
+  customElements.enableFlush = true;
+
+  setup(function() {
+    work = document.createElement('div');
+    document.body.appendChild(work);
+  });
+
+  teardown(function() {
+    document.body.removeChild(work);
+  });
+
+  suite('defining', function() {
+
+    test('requires a name argument', function() {
+      assert.throws(function() {
+        customElements.polyfillDefineLazy();
+      }, '', 'customElements.define failed to throw when given no arguments');
+    });
+
+    test('name must contain a dash', function() {
+      assert.throws(function () {
+        customElements.polyfillDefineLazy('xfoo', () => {prototype: Object.create(HTMLElement.prototype)});
+      }, '', 'customElements.define failed to throw when given no arguments');
+    });
+
+    test('name must not be a reserved name', function() {
+      assert.throws(function() {
+        customElements.polyfillDefineLazy('font-face', () => {prototype: Object.create(HTMLElement.prototype)});
+      }, '', 'Failed to execute \'defineElement\' on \'Document\': Registration failed for type \'font-face\'. The type name is invalid.');
+    });
+
+    test('name must be unique', function() {
+      const generator = () => class XDuplicate extends HTMLElement {};
+      customElements.polyfillDefineLazy('x-lazy-duplicate', generator);
+      assert.throws(function() {
+        customElements.polyfillDefineLazy('x-lazy-duplicate', generator);
+      }, '', 'customElements.define failed to throw when called multiple times with the same element name');
+    });
+
+    test('name must be unique and not defined', function() {
+      customElements.define('x-lazy-duplicate-define', class extends HTMLElement {});
+      assert.throws(function() {
+        customElements.polyfillDefineLazy('x-lazy-duplicate-define', () => class extends HTMLElement {});
+      }, '', 'customElements.define failed to throw when called multiple times with the same element name');
+    });
+
+    test('names are case-sensitive', function() {
+      const generator = () => class XCase extends HTMLElement {};
+      assert.throws(function() { customElements.polyfillDefineLazy('X-CASE', generator); });
+    });
+
+    test('requires a constructor argument', function() {
+      assert.throws(function () {
+        customElements.polyfillDefineLazy('x-no-options');
+      }, '', 'customElements.define failed to throw without a constructor argument');
+    });
+
+  });
+
+  suite('get', function() {
+
+    test('returns undefined and constructor after element upgrades', function() {
+      customElements.polyfillDefineLazy('x-get-lazy', () => class extends HTMLElement {});
+      assert.isUndefined(customElements.get('x-get-lazy'));
+      document.createElement('x-get-lazy');
+      assert.ok(customElements.get('x-get-lazy'));
+    });
+
+  });
+
+  suite('whenDefined', function() {
+
+    test('resolves when a lazy define is first upgraded', function() {
+      customElements.polyfillDefineLazy('x-when-defined-lazy', () =>class extends HTMLElement {});
+      const el = document.createElement('x-when-defined-lazy');
+      work.appendChild(el);
+      return customElements.whenDefined('x-when-defined-lazy');
+    });
+
+  });
+
+  suite('upgrades', function() {
+
+    test('createElement upgrades when defined', function() {
+      customElements.polyfillDefineLazy('lazy-create-upgrade', () => {
+        return class extends HTMLElement {
+          constructor() {
+            super();
+            this.upgraded = true;
+          }
+        }
+      });
+      const el = document.createElement('lazy-create-upgrade');
+      assert.isTrue(el.upgraded);
+    });
+
+    test('element in dom upgrades', function() {
+      const el = document.createElement('lazy-dom-upgrade');
+      work.appendChild(el);
+      customElements.polyfillDefineLazy('lazy-dom-upgrade', () => {
+        return class extends HTMLElement {
+          constructor() {
+            super();
+            this.upgraded = true;
+          }
+          connectedCallback() {
+            this.connected = true;
+          }
+        }
+      });
+      assert.isTrue(el.upgraded);
+      assert.isTrue(el.connected);
+    });
+
+   });
+
+});

--- a/tests/js/reactions.js
+++ b/tests/js/reactions.js
@@ -176,6 +176,14 @@ suite('Custom Element Reactions', function() {
       assert.isTrue(passed);
     });
 
+    test('constructor throws if it does not produce an HTMLElement', function() {
+      class XFail {}
+      customElements.define('x-fail-to-be-html-element', XFail);
+      assert.throws(function() {
+        document.createElement('x-fail-to-be-html-element');
+      })
+    });
+
   });
 
   suite('attributeChangedCallback', function() {


### PR DESCRIPTION
This is an optional optimization which allows defining an element with a function that returns a class. This function is called the first time the polyfill tries to upgrade an element of the given name. It allows the polyfill to defer any work needed to generate the element class or its callbacks until this work is actually needed.