### PR TITLE
Fix error reporting when define throws while reading callbacks

### DIFF
--- a/externs/custom-elements.js
+++ b/externs/custom-elements.js
@@ -68,3 +68,7 @@ Element.prototype.__CE_definition;
 
 /** @type {!DocumentFragment|undefined} */
 Element.prototype.__CE_shadowRoot;
+
+// Note, the closure type is incorrect here.
+/** @type {!HTMLCollection} */
+DocumentFragment.prototype.children;

--- a/src/CustomElementInternals.js
+++ b/src/CustomElementInternals.js
@@ -16,7 +16,7 @@ export default class CustomElementInternals {
   /**
    * @param {{
    *   shadyDomFastWalk: boolean,
-   *   useDocumentConstructionObserver: boolean,
+   *   noDocumentConstructionObserver: boolean,
    * }} options
    */
   constructor(options) {

--- a/src/CustomElementRegistry.js
+++ b/src/CustomElementRegistry.js
@@ -113,9 +113,12 @@ export default class CustomElementRegistry {
       disconnectedCallback = getCallback('disconnectedCallback');
       adoptedCallback = getCallback('adoptedCallback');
       attributeChangedCallback = getCallback('attributeChangedCallback');
-      observedAttributes = constructor['observedAttributes'] || [];
+      // `observedAttributes` should not be read unless an
+      // `attributesChangedCallback` exists
+      observedAttributes = (attributeChangedCallback &&
+        constructor['observedAttributes']) || [];
     } catch (e) {
-      return;
+      throw e;
     } finally {
       this._elementDefinitionIsRunning = false;
     }

--- a/tests/js/registry.js
+++ b/tests/js/registry.js
@@ -77,6 +77,48 @@ suite('CustomElementsRegistry', function() {
       }, '', 'customElements.define failed to throw with a constructor argument with no prototype');
     });
 
+    test('fails if reading callbacks fails', function() {
+      assert.throws(function () {
+        customElements.define('x-bad-attributes', class extends HTMLElement {
+          attributeChangedCallback() {}
+          static get observedAttributes() {
+            throw new Error('no attributes');
+          }
+        });
+      }, '', 'customElements.define failed to throw when reading callback throws.');
+    });
+
+    test('succeeds with named used for a failed definition with invalid class', function() {
+      try {
+        customElements.define('x-failed-define', {});
+      } catch (e) {}
+      let error;
+      try {
+        customElements.define('x-failed-define', class extends HTMLElement {});
+      } catch (e) {
+        error = e;
+      }
+      assert.isUndefined(error, 'Error thrown when defining an element using the same name as a failed definition with an invalid class.')
+    });
+
+    test('succeeds with named used for a failed definition with invalid callbacks', function() {
+      try {
+        customElements.define('x-failed-define-callbacks', class extends HTMLElement {
+          attributeChangedCallback() {}
+          static get observedAttributes() {
+            throw new Error('no attributes');
+          }
+        });
+      } catch (e) {}
+      let error;
+      try {
+        customElements.define('x-failed-define-callbacks', class extends HTMLElement {});
+      } catch (e) {
+        error = e;
+      }
+      assert.isUndefined(error, 'Error thrown when defining an element using the same name as a failed definition with invalid callbacks.')
+    });
+
   });
 
   suite('get', function() {


### PR DESCRIPTION
Fixes #210. When gathering callbacks fails, throw the reported error.

Also fixes an issue with reading observedAttributes when attributesChangedCallback was not defined.